### PR TITLE
Cache Graph Isomorphism

### DIFF
--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -276,8 +276,8 @@ def rmsd_isomorphic(
         am2,
         atomicnums1,
         atomicnums2,
-        center,
-        minimize,
+        center=center,
+        minimize=minimize,
         isomorphisms=None,
     )
 
@@ -340,8 +340,8 @@ def multirmsd_isomorphic(
             am,
             atomicnumsref,
             atomicnums,
-            center,
-            minimize,
+            center=center,
+            minimize=minimize,
             isomorphisms=isomorphism,
         )
 

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -255,6 +255,7 @@ def rmsd_isomorphic(
         Centering flag
     minimize: bool
         Minimum RMSD
+
     Returns
     -------
     float
@@ -281,3 +282,69 @@ def rmsd_isomorphic(
     )
 
     return RMSD
+
+
+def multirmsd_isomorphic(
+    coordsref: np.ndarray,
+    coords: List[np.ndarray],
+    amref: np.ndarray,
+    am: np.ndarray,
+    atomicnumsref: np.ndarray = None,
+    atomicnums: np.ndarray = None,
+    center: bool = False,
+    minimize: bool = False,
+) -> List[float]:
+    """
+    Compute RMSD using graph isomorphism for multiple coordinates.
+
+    Parameters
+    ----------
+    coordsref: np.ndarray
+        Coordinate of reference molecule
+    coords: List[np.ndarray]
+        Coordinates of other molecule
+    amref: np.ndarray
+        Adjacency matrix for reference molecule
+    am: np.ndarray
+        Adjacency matrix for other molecule
+    atomicnumsref: npndarray, optional
+        Atomic numbers for reference
+    atomicnums: npndarray, optional
+        Atomic numbers for other molecule
+    center: bool
+        Centering flag
+    minimize: bool
+        Minimum RMSD
+
+    Returns
+    -------
+    float
+        RMSD (after graph matching) and graph isomorphisms
+
+    Notes
+    -----
+
+    This QCP method, activated with the keyword `minimize=True` works in cases where
+    the atoms in `mol1` and `mol2` are not in the exact same order. If the atoms in
+    `mol1` and `mol2` are in the same order use `rmsd_qcp` (faster).
+    """
+
+    RMSDlist, isomorphism = [], None
+
+    for c in coords:
+
+        RMSD, isomorphism = _rmsd_isomorphic_core(
+            coordsref,
+            c,
+            amref,
+            am,
+            atomicnumsref,
+            atomicnums,
+            center,
+            minimize,
+            isomorphisms=isomorphism,
+        )
+
+        RMSDlist.append(RMSD)
+
+    return RMSDlist

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -293,6 +293,7 @@ def multirmsd_isomorphic(
     atomicnums: np.ndarray = None,
     center: bool = False,
     minimize: bool = False,
+    cache: bool = True,
 ) -> List[float]:
     """
     Compute RMSD using graph isomorphism for multiple coordinates.
@@ -332,6 +333,10 @@ def multirmsd_isomorphic(
     RMSDlist, isomorphism = [], None
 
     for c in coords:
+
+        if not cache:
+            # Reset isomorphism
+            isomorphism = None
 
         RMSD, isomorphism = _rmsd_isomorphic_core(
             coordsref,

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -129,20 +129,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n", "--nosymm", action="store_false", help="No graph isomorphism"
     )
-    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
 
     args = parser.parse_args()
-
-    output: str = ""
 
     inref = io.load(args.reference)
     ref = io.to_molecule(inref, adjacency=True)
 
-    if args.verbose:
-        refname = os.path.basename(args.reference)
-
     # Load all molecules
-    inmols = [io.loadall(molfile) for molfile in args.molecules]
+    inmols = [inmol for molfile in args.molecules for inmol in io.loadall(molfile)]
     mols = [io.to_molecule(mol, adjacency=True) for mol in inmols]
 
     # Loop over molecules within fil
@@ -155,4 +149,5 @@ if __name__ == "__main__":
         strip=not args.hydrogens,
     )
 
-    # print(f"{output}{r:.5f}")
+    for RMSD in RMSDlist:
+        print(f"{RMSD:.5f}")

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -46,6 +46,7 @@ def rmsdwrapper(
     center: bool = False,
     minimize: bool = False,
     strip: bool = False,
+    cache: bool = True,
 ) -> List[float]:
     """
     Compute RMSD between two molecule.
@@ -95,6 +96,7 @@ def rmsdwrapper(
             mols[0].atomicnums,
             center=center,
             minimize=minimize,
+            cache=cache,
         )
     elif minimize and not symmetry:
         for c in cmols:

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     RMSDlist = rmsdwrapper(
         ref,
         mols,
-        symmetry=args.nosymm,
+        symmetry=args.nosymm, # args.nosymm store False
         center=args.center,
         minimize=args.minimize,
         strip=not args.hydrogens,

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -2,7 +2,7 @@
 Python RMSD tool
 """
 
-from typing import Dict, List, Optional, Tuple
+from typing import List
 
 import numpy as np
 
@@ -40,13 +40,13 @@ def coords_from_molecule(mol: molecule.Molecule, center: bool = False) -> np.nda
 
 
 def rmsdwrapper(
-    mol1,
-    mol2,
+    molref,
+    mols,
     symmetry: bool = True,
     center: bool = False,
     minimize: bool = False,
     strip: bool = False,
-) -> Tuple[float, Optional[List[Dict[int, int]]]]:
+) -> List[float]:
     """
     Compute RMSD between two molecule.
 
@@ -67,43 +67,47 @@ def rmsdwrapper(
 
     Returns
     -------
-    float
-        RMSD
+    List[float]
+        RMSDs
     """
 
     if strip:
-        mol1.strip()  # Does nothing if already stripped
-        mol2.strip()
+        molref.strip()
+
+        for mol in mols:
+            mol.strip()
 
     if minimize:
         center = True
 
-    c1 = coords_from_molecule(mol1, center)
-    c2 = coords_from_molecule(mol2, center)
+    cref = coords_from_molecule(molref, center)
+    cmols = [coords_from_molecule(mol, center) for mol in mols]
 
-    if c1.shape != c2.shape:
-        # TODO: Create specific exception
-        raise ValueError("Molecules have different sizes.")
-
-    RMSD = np.inf
+    RMSDlist = []
 
     if symmetry:
-        RMSD = rmsd.rmsd_isomorphic(
-            c1,
-            c2,
-            mol1.adjacency_matrix,
-            mol2.adjacency_matrix,
-            mol1.atomicnums,
-            mol2.atomicnums,
+        RMSDlist = rmsd.multirmsd_isomorphic(
+            cref,
+            cmols,
+            molref.adjacency_matrix,
+            mols[0].adjacency_matrix,
+            molref.atomicnums,
+            mols[0].atomicnums,
             center=center,
             minimize=minimize,
         )
     elif minimize and not symmetry:
-        RMSD = rmsd.rmsd_qcp(c1, c2, mol1.atomicnums, mol2.atomicnums)
+        for c in cmols:
+            RMSDlist.append(
+                rmsd.rmsd_qcp(cref, c, molref.atomicnums, mols[0].atomicnums)
+            )
     elif not minimize and not symmetry:
-        RMSD = rmsd.rmsd_standard(c1, c2, mol1.atomicnums, mol2.atomicnums)
+        for c in cmols:
+            RMSDlist.append(
+                rmsd.rmsd_standard(cref, c, molref.atomicnums, mols[0].atomicnums)
+            )
 
-    return RMSD
+    return RMSDlist
 
 
 if __name__ == "__main__":
@@ -131,34 +135,24 @@ if __name__ == "__main__":
 
     output: str = ""
 
-    obref = io.load(args.reference)
-    ref = io.to_molecule(obref, adjacency=True)
+    inref = io.load(args.reference)
+    ref = io.to_molecule(inref, adjacency=True)
 
     if args.verbose:
         refname = os.path.basename(args.reference)
 
-    # Loop over input files
-    for molfile in args.molecules:
+    # Load all molecules
+    inmols = [io.loadall(molfile) for molfile in args.molecules]
+    mols = [io.to_molecule(mol, adjacency=True) for mol in inmols]
 
-        # Load all molecule within file
-        obmols = io.loadall(molfile)
-        mols = [io.to_molecule(obmol, adjacency=True) for obmol in obmols]
+    # Loop over molecules within fil
+    RMSDlist = rmsdwrapper(
+        ref,
+        mols,
+        symmetry=args.nosymm,
+        center=args.center,
+        minimize=args.minimize,
+        strip=not args.hydrogens,
+    )
 
-        if args.verbose:
-            molname = os.path.basename(molfile)
-
-            output = f"{refname}:{molname} "
-
-        # Loop over molecules within file
-        for idx, mol in enumerate(mols):
-
-            r = rmsdwrapper(
-                ref,
-                mol,
-                symmetry=args.nosymm,
-                center=args.center,
-                minimize=args.minimize,
-                strip=not args.hydrogens,
-            )
-
-            print(f"{output}{r:.5f}")
+    # print(f"{output}{r:.5f}")

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     RMSDlist = rmsdwrapper(
         ref,
         mols,
-        symmetry=args.nosymm, # args.nosymm store False
+        symmetry=args.nosymm,  # args.nosymm store False
         center=args.center,
         minimize=args.minimize,
         strip=not args.hydrogens,

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -115,7 +115,6 @@ if __name__ == "__main__":
     from spyrmsd import io
 
     import argparse as ap
-    import os
 
     parser = ap.ArgumentParser(description="Python RMSD tool.")
 

--- a/tests/molecules.py
+++ b/tests/molecules.py
@@ -74,6 +74,7 @@ for i in [1, 2, 3]:
 obdocking_1cbr = [load("1cbr_ligand.mol2")[0], *loadall("1cbr_docking.sdf")[0]]
 docking_1cbr = [load("1cbr_ligand.mol2")[1], *loadall("1cbr_docking.sdf")[1]]
 
-obtrp, trp = {}, {}
+intrp, trp = [], []
 for i in range(6):
-    obtrp[i], trp[i] = load(f"trp{i}.pdb")
+    intrp.append(load(f"trp{i}.pdb")[0])
+    trp.append(load(f"trp{i}.pdb")[1])

--- a/tests/test_pyrmsd.py
+++ b/tests/test_pyrmsd.py
@@ -1,26 +1,15 @@
 import copy
 import sys
+from typing import List
 
 import pytest
 
-from spyrmsd import molecule, spyrmsd
+from spyrmsd import spyrmsd
 from tests import molecules
 
 
 def test_spyrmsd_imported():
     assert "spyrmsd" in sys.modules
-
-
-@pytest.mark.parametrize("mol", molecules.allmolecules)
-def test_rmsdwrapper_molsize(mol: molecule.Molecule) -> None:
-
-    m = copy.deepcopy(mol)
-    ms = copy.deepcopy(mol)
-
-    ms.strip()
-
-    with pytest.raises(ValueError):
-        spyrmsd.rmsdwrapper(m, ms, symmetry=False)
 
 
 # Results obtained with MDAnalysis
@@ -33,72 +22,83 @@ def test_rmsdwrapper_molsize(mol: molecule.Molecule) -> None:
 #       _, rmsd_min = align.rotation_matrix(tc, tc0)
 #       print(rmsd_dummy, rmsd_min)
 @pytest.mark.parametrize(
-    "i, rmsd_dummy, rmsd_min",
+    "minimize, referenceRMSDs",
     [
-        (1, 4.812480551076202, 1.6578281551053196),
-        (2, 6.772045449820714, 1.7175638492348284),
-        (3, 9.344911262612964, 1.5946081072641485),
-        (4, 9.772939589989000, 2.1234944939308220),
-        (5, 8.901837608843241, 2.4894805175766606),
+        (
+            False,  # No minimize: dummy RMSD
+            [
+                4.812480551076202,
+                6.772045449820714,
+                9.344911262612964,
+                9.772939589989000,
+                8.901837608843241,
+            ],
+        ),
+        (
+            True,  # Minimize: QCP
+            [
+                1.6578281551053196,
+                1.7175638492348284,
+                1.5946081072641485,
+                2.1234944939308220,
+                2.4894805175766606,
+            ],
+        ),
     ],
 )
-def test_rmsdwrapper_qcp_protein(i: int, rmsd_dummy: float, rmsd_min: float):
+def test_rmsdwrapper_nosymm_protein(minimize: bool, referenceRMSDs: List[float]):
 
     mol0 = copy.deepcopy(molecules.trp[0])
-    mol = copy.deepcopy(molecules.trp[i])
+    mols = [copy.deepcopy(mol) for mol in molecules.trp[1:]]
 
-    assert spyrmsd.rmsdwrapper(mol0, mol, symmetry=False) == pytest.approx(rmsd_dummy)
+    RMSDs = spyrmsd.rmsdwrapper(mol0, mols, symmetry=False, minimize=minimize)
 
-    assert spyrmsd.rmsdwrapper(
-        mol0, mol, symmetry=False, minimize=True
-    ) == pytest.approx(rmsd_min)
+    for RMSD, referenceRMSD in zip(RMSDs, referenceRMSDs):
+        assert RMSD == pytest.approx(referenceRMSD)
 
 
-# Results obtained with OpenBabel
 @pytest.mark.parametrize(
-    "index, RMSD",
+    # Reference results obtained with OpenBabel
+    "minimize, referenceRMSDs",
     [
-        (1, 0.592256),
-        (2, 2.11545),
-        (3, 2.29824),
-        (4, 9.45773),
-        (5, 1.35005),
-        (6, 9.44356),
-        (7, 9.59758),
-        (8, 9.55076),
-        (9, 2.44067),
-        (10, 9.6171),
+        (
+            True,  # Minimize: QCP + Isomorphism
+            [
+                0.476858,
+                1.68089,
+                1.50267,
+                1.90623,
+                1.01324,
+                1.31716,
+                1.11312,
+                1.06044,
+                0.965387,
+                1.37842,
+            ],
+        ),
+        (
+            False,  # No minimize: Isomorphism only
+            [
+                0.592256,
+                2.11545,
+                2.29824,
+                9.45773,
+                1.35005,
+                9.44356,
+                9.59758,
+                9.55076,
+                2.44067,
+                9.6171,
+            ],
+        ),
     ],
 )
-def test_rmsdwrapper_isomorphic(index: int, RMSD: float) -> None:
+def test_rmsdwrapper_isomorphic(minimize: bool, referenceRMSDs: List[float]) -> None:
 
-    molc = copy.deepcopy(molecules.docking_1cbr[0])
-    mol = copy.deepcopy(molecules.docking_1cbr[index])
+    molref = copy.deepcopy(molecules.docking_1cbr[0])
+    mols = [copy.deepcopy(mol) for mol in molecules.docking_1cbr[1:]]
 
-    assert spyrmsd.rmsdwrapper(mol, molc, strip=True) == pytest.approx(RMSD, abs=1e-5)
+    RMSDs = spyrmsd.rmsdwrapper(molref, mols, minimize=minimize, strip=True)
 
-
-# Results obtained with OpenBabel
-@pytest.mark.parametrize(
-    "index, RMSD",
-    [
-        (1, 0.476858),
-        (2, 1.68089),
-        (3, 1.50267),
-        (4, 1.90623),
-        (5, 1.01324),
-        (6, 1.31716),
-        (7, 1.11312),
-        (8, 1.06044),
-        (9, 0.965387),
-        (10, 1.37842),
-    ],
-)
-def test_rmsdwrapper_isomorphic_minimized(index: int, RMSD: float) -> None:
-
-    molc = copy.deepcopy(molecules.docking_1cbr[0])
-    mol = copy.deepcopy(molecules.docking_1cbr[index])
-
-    assert spyrmsd.rmsdwrapper(mol, molc, minimize=True, strip=True) == pytest.approx(
-        RMSD, abs=1e-5
-    )
+    for RMSD, referenceRMSD in zip(RMSDs, referenceRMSDs):
+        assert RMSD == pytest.approx(referenceRMSD, abs=1e-5)

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -492,3 +492,66 @@ def test_multirmsd_isomorphic(minimize: bool, referenceRMSDs: List[float]) -> No
 
     for RMSD, referenceRMSD in zip(RMSDs, referenceRMSDs):
         assert RMSD == pytest.approx(referenceRMSD, abs=1e-5)
+
+
+# Results obtained with OpenBabel
+@pytest.mark.parametrize(
+    "minimize, referenceRMSDs",
+    [
+        (
+            False,
+            [
+                0.592256,
+                2.11545,
+                2.29824,
+                9.45773,
+                1.35005,
+                9.44356,
+                9.59758,
+                9.55076,
+                2.44067,
+                9.6171,
+            ],
+        ),
+        (
+            True,
+            [
+                0.476858,
+                1.68089,
+                1.50267,
+                1.90623,
+                1.01324,
+                1.31716,
+                1.11312,
+                1.06044,
+                0.965387,
+                1.37842,
+            ],
+        ),
+    ],
+)
+def test_multirmsd_isomorphic_cache(
+    minimize: bool, referenceRMSDs: List[float]
+) -> None:
+
+    molc = copy.deepcopy(molecules.docking_1cbr[0])
+    mols = [copy.deepcopy(mol) for mol in molecules.docking_1cbr[1:]]
+
+    molc.strip()
+
+    for mol in mols:
+        mol.strip()
+
+    RMSDs = rmsd.multirmsd_isomorphic(
+        molc.coordinates,
+        [mol.coordinates for mol in mols],
+        molc.adjacency_matrix,
+        mols[0].adjacency_matrix,
+        molc.atomicnums,
+        mols[0].atomicnums,
+        minimize=minimize,
+        cache=False,
+    )
+
+    for RMSD, referenceRMSD in zip(RMSDs, referenceRMSDs):
+        assert RMSD == pytest.approx(referenceRMSD, abs=1e-5)

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -6,6 +6,8 @@ import pytest
 from spyrmsd import molecule, rmsd
 from tests import molecules
 
+from typing import List
+
 
 def test_rmsd_dummy_benzene() -> None:
 
@@ -389,21 +391,31 @@ def test_rmsd_isomorphic_atomicnums_matching_pyridine_stripped() -> None:
 
 # Results obtained with OpenBabel
 @pytest.mark.parametrize(
-    "index, RMSD",
+    "index, RMSD, minimize",
     [
-        (1, 0.592256),
-        (2, 2.11545),
-        (3, 2.29824),
-        (4, 9.45773),
-        (5, 1.35005),
-        (6, 9.44356),
-        (7, 9.59758),
-        (8, 9.55076),
-        (9, 2.44067),
-        (10, 9.6171),
+        (1, 0.592256, False),
+        (2, 2.11545, False),
+        (3, 2.29824, False),
+        (4, 9.45773, False),
+        (5, 1.35005, False),
+        (6, 9.44356, False),
+        (7, 9.59758, False),
+        (8, 9.55076, False),
+        (9, 2.44067, False),
+        (10, 9.6171, False),
+        (1, 0.476858, True),
+        (2, 1.68089, True),
+        (3, 1.50267, True),
+        (4, 1.90623, True),
+        (5, 1.01324, True),
+        (6, 1.31716, True),
+        (7, 1.11312, True),
+        (8, 1.06044, True),
+        (9, 0.965387, True),
+        (10, 1.37842, True),
     ],
 )
-def test_rmsd_isomorphic(index: int, RMSD: float) -> None:
+def test_rmsd_isomorphic(index: int, RMSD: float, minimize: bool) -> None:
 
     molc = copy.deepcopy(molecules.docking_1cbr[0])
     mol = copy.deepcopy(molecules.docking_1cbr[index])
@@ -418,39 +430,65 @@ def test_rmsd_isomorphic(index: int, RMSD: float) -> None:
         mol.adjacency_matrix,
         molc.atomicnums,
         mol.atomicnums,
+        minimize=minimize,
     ) == pytest.approx(RMSD, abs=1e-5)
 
 
 # Results obtained with OpenBabel
 @pytest.mark.parametrize(
-    "index, RMSD",
+    "minimize, referenceRMSDs",
     [
-        (1, 0.476858),
-        (2, 1.68089),
-        (3, 1.50267),
-        (4, 1.90623),
-        (5, 1.01324),
-        (6, 1.31716),
-        (7, 1.11312),
-        (8, 1.06044),
-        (9, 0.965387),
-        (10, 1.37842),
+        (
+            False,
+            [
+                0.592256,
+                2.11545,
+                2.29824,
+                9.45773,
+                1.35005,
+                9.44356,
+                9.59758,
+                9.55076,
+                2.44067,
+                9.6171,
+            ],
+        ),
+        (
+            True,
+            [
+                0.476858,
+                1.68089,
+                1.50267,
+                1.90623,
+                1.01324,
+                1.31716,
+                1.11312,
+                1.06044,
+                0.965387,
+                1.37842,
+            ],
+        ),
     ],
 )
-def test_rmsd_isomorphic_minimize(index: int, RMSD: float) -> None:
+def test_multirmsd_isomorphic(minimize: bool, referenceRMSDs: List[float]) -> None:
 
     molc = copy.deepcopy(molecules.docking_1cbr[0])
-    mol = copy.deepcopy(molecules.docking_1cbr[index])
+    mols = [copy.deepcopy(mol) for mol in molecules.docking_1cbr[1:]]
 
     molc.strip()
-    mol.strip()
 
-    assert rmsd.rmsd_isomorphic(
+    for mol in mols:
+        mol.strip()
+
+    RMSDs = rmsd.multirmsd_isomorphic(
         molc.coordinates,
-        mol.coordinates,
+        [mol.coordinates for mol in mols],
         molc.adjacency_matrix,
-        mol.adjacency_matrix,
+        mols[0].adjacency_matrix,
         molc.atomicnums,
-        mol.atomicnums,
-        minimize=True,
-    ) == pytest.approx(RMSD, abs=1e-5)
+        mols[0].atomicnums,
+        minimize=minimize,
+    )
+
+    for RMSD, referenceRMSD in zip(RMSDs, referenceRMSDs):
+        assert RMSD == pytest.approx(referenceRMSD, abs=1e-5)


### PR DESCRIPTION
## Description

Add `multirmsd_isomorphic` function to cache the graph isomorphism. Caching can be turned off with the `cache=False` argument.

![time](https://user-images.githubusercontent.com/11348981/74265029-a3638f00-4cf9-11ea-8d08-52827bb17ec1.png)

Caching makes `spyrmsd` much faster in most cases (`28.25` ms on average with cache versus ` 143.24` ms on average without cache, for the first 75 systems) but it's still an order of magnitude slower than `obrms` (`6.74` ms on average).

Solves #11.