### PR TITLE
Reset Graph when Stripping

### DIFF
--- a/spyrmsd/molecule.py
+++ b/spyrmsd/molecule.py
@@ -133,6 +133,9 @@ class Molecule:
             if self.adjacency_matrix is not None:
                 self.adjacency_matrix = self.adjacency_matrix[np.ix_(idx, idx)]
 
+            # Reset molecular graph when stripping
+            self.G = None
+
             self.stripped = True
 
     def to_graph(self):


### PR DESCRIPTION
## Description
Fix #17 by invalidating the molecular graph (`self.G = None`) after stripping hydrogen atoms. This prevents possible divergence between the molecular graph and the adjacency matrix.