### PR TITLE
Make OpenBabel and RDKit Optional

### DIFF
--- a/spyrmsd/io.py
+++ b/spyrmsd/io.py
@@ -10,22 +10,39 @@ try:
     )
 
 except ImportError:
-    from spyrmsd.optional.rdkit import (
-        load,
-        loadall,
-        adjacency_matrix,
-        to_molecule,
-        numatoms,
-        numbonds,
-        bonds,
-    )
 
-__all__ = [
-    "load",
-    "loadall",
-    "adjacency_matrix",
-    "to_molecule",
-    "numatoms",
-    "numbonds",
-    "bonds",
-]
+    try:
+        from spyrmsd.optional.rdkit import (
+            load,
+            loadall,
+            adjacency_matrix,
+            to_molecule,
+            numatoms,
+            numbonds,
+            bonds,
+        )
+    except ImportError:
+        # Use sPyRMSD as standalone library
+        __all__ = []
+    else:
+        # Avoid flake8 complaint "imported but unused"
+        __all__ = [
+            "load",
+            "loadall",
+            "adjacency_matrix",
+            "to_molecule",
+            "numatoms",
+            "numbonds",
+            "bonds",
+        ]
+else:
+    # Avoid flake8 complaint "imported but unused"
+    __all__ = [
+        "load",
+        "loadall",
+        "adjacency_matrix",
+        "to_molecule",
+        "numatoms",
+        "numbonds",
+        "bonds",
+    ]


### PR DESCRIPTION
## Description

Make OpenBabel and RDKit completely optional, so that `spyrmsd` can be used as a standalone library.