### PR TITLE
Load Molecules Into Molecule Object

### DIFF
--- a/docs/source/tutorials/tutorial.ipynb
+++ b/docs/source/tutorials/tutorial.ipynb
@@ -56,14 +56,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ref = io.to_molecule(io.load(\"molecules/1a4k_ligand.sdf\"))"
+    "ref = io.loadmol(\"molecules/1a4k_ligand.sdf\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`io.load` load a single molecule from a file. In order to load all molecules we need to use `io.loadall`:"
+    "`io.loadmol` load a single molecule from a file. In order to load all molecules we need to use `io.loadallmols`:"
    ]
   },
   {
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mols = [io.to_molecule(mol) for mol in io.loadall(\"molecules/1a4k_dock.sdf\")]"
+    "mols = io.loadallmols(\"molecules/1a4k_dock.sdf\")"
    ]
   },
   {

--- a/docs/source/tutorials/tutorial.rst
+++ b/docs/source/tutorials/tutorial.rst
@@ -30,14 +30,14 @@ object:
 
 .. code:: ipython3
 
-    ref = io.to_molecule(io.load("molecules/1a4k_ligand.sdf"))
+    ref = io.loadmol("molecules/1a4k_ligand.sdf")
 
-``io.load`` load a single molecule from a file. In order to load all
-molecules we need to use ``io.loadall``:
+``io.loadmol`` load a single molecule from a file. In order to load all
+molecules we need to use ``io.loadallmols``:
 
 .. code:: ipython3
 
-    mols = [io.to_molecule(mol) for mol in io.loadall("molecules/1a4k_dock.sdf")]
+    mols = io.loadallmols("molecules/1a4k_dock.sdf")
 
 Removing Hydrogen Atoms
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/spyrmsd/graphs/gt.py
+++ b/spyrmsd/graphs/gt.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, List, Optional, Union, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import graph_tool as gt
 import numpy as np

--- a/spyrmsd/graphs/nx.py
+++ b/spyrmsd/graphs/nx.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, List, Optional, Union, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import networkx as nx
 import numpy as np

--- a/spyrmsd/io.py
+++ b/spyrmsd/io.py
@@ -52,7 +52,7 @@ from typing import List
 from spyrmsd import molecule
 
 
-def loadmol(fname: str) -> molecule.Molecule:
+def loadmol(fname: str, adjacency: bool = True) -> molecule.Molecule:
     """
     Load molecule from file.
 
@@ -69,10 +69,10 @@ def loadmol(fname: str) -> molecule.Molecule:
 
     mol = load(fname)
 
-    return to_molecule(mol)
+    return to_molecule(mol, adjacency=adjacency)
 
 
-def loadallmols(fname: str) -> List[molecule.Molecule]:
+def loadallmols(fname: str, adjacency: bool = True) -> List[molecule.Molecule]:
     """
     Load molecules from file.
 
@@ -89,4 +89,4 @@ def loadallmols(fname: str) -> List[molecule.Molecule]:
 
     mols = loadall(fname)
 
-    return [to_molecule(mol) for mol in mols]
+    return [to_molecule(mol, adjacency=adjacency) for mol in mols]

--- a/spyrmsd/io.py
+++ b/spyrmsd/io.py
@@ -46,3 +46,47 @@ else:
         "numbonds",
         "bonds",
     ]
+
+from typing import List
+
+from spyrmsd import molecule
+
+
+def loadmol(fname: str) -> molecule.Molecule:
+    """
+    Load molecule from file.
+
+    Parameters
+    ----------
+    fname: str
+        File name
+
+    Returns
+    -------
+    molecule.Molecule
+        `spyrmsd` molecule
+    """
+
+    mol = load(fname)
+
+    return to_molecule(mol)
+
+
+def loadallmols(fname: str) -> List[molecule.Molecule]:
+    """
+    Load molecules from file.
+
+    Parameters
+    ----------
+    fname: str
+        File name
+
+    Returns
+    -------
+    List[molecule.Molecule]
+        `spyrmsd` molecules
+    """
+
+    mols = loadall(fname)
+
+    return [to_molecule(mol) for mol in mols]

--- a/spyrmsd/optional/obabel.py
+++ b/spyrmsd/optional/obabel.py
@@ -56,7 +56,8 @@ def loadall(fname: str):
     # FIXME: Special handling for multi-model PDB files
     # See OpenBabel Issue #2097
     if fmt == "pdb":
-        obmols = obmols[:-1]
+        if len(obmols) > 1: # Multi-model PDB file
+            obmols = obmols[:-1]
 
     return obmols
 

--- a/spyrmsd/optional/obabel.py
+++ b/spyrmsd/optional/obabel.py
@@ -56,7 +56,7 @@ def loadall(fname: str):
     # FIXME: Special handling for multi-model PDB files
     # See OpenBabel Issue #2097
     if fmt == "pdb":
-        if len(obmols) > 1: # Multi-model PDB file
+        if len(obmols) > 1:  # Multi-model PDB file
             obmols = obmols[:-1]
 
     return obmols

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -139,8 +139,7 @@ if __name__ == "__main__":
     ref = io.to_molecule(inref, adjacency=True)
 
     # Load all molecules
-    inmols = [inmol for molfile in args.molecules for inmol in io.loadall(molfile)]
-    mols = [io.to_molecule(mol, adjacency=True) for mol in inmols]
+    mols = [mol for molfile in args.molecules for mol in io.loadallmols(molfile)]
 
     # Loop over molecules within fil
     RMSDlist = rmsdwrapper(

--- a/tests/data/molecules/1a99_ligand.pdb
+++ b/tests/data/molecules/1a99_ligand.pdb
@@ -1,0 +1,43 @@
+CRYST1    0.000    0.000    0.000   0.00   0.00   0.00               1
+HETATM    1  C1  LIG   683      60.308  61.793  60.770  1.00  0.00           C  
+HETATM    2  N1  LIG   683      59.207  60.981  61.431  1.00  0.00           N  
+HETATM    3  C2  LIG   683      59.742  63.029  60.057  1.00  0.00           C  
+HETATM    4  N2  LIG   683      61.270  66.401  58.868  1.00  0.00           N  
+HETATM    5  C3  LIG   683      60.815  64.109  59.833  1.00  0.00           C  
+HETATM    6  C4  LIG   683      60.252  65.296  59.035  1.00  0.00           C  
+HETATM    7  H1  LIG   683      59.533  60.028  61.701  1.00  0.00           H  
+HETATM    8  H2  LIG   683      58.355  60.876  60.830  1.00  0.00           H  
+HETATM    9  H3  LIG   683      58.877  61.426  62.298  1.00  0.00           H  
+HETATM   10  H4  LIG   683      60.840  61.161  60.050  1.00  0.00           H  
+HETATM   11  H5  LIG   683      61.034  62.094  61.537  1.00  0.00           H  
+HETATM   12  H6  LIG   683      58.928  63.450  60.658  1.00  0.00           H  
+HETATM   13  H7  LIG   683      59.297  62.723  59.101  1.00  0.00           H  
+HETATM   14  H8  LIG   683      61.677  63.683  59.303  1.00  0.00           H  
+HETATM   15  H9  LIG   683      61.183  64.461  60.807  1.00  0.00           H  
+HETATM   16  H10 LIG   683      59.374  65.706  59.546  1.00  0.00           H  
+HETATM   17  H11 LIG   683      59.937  64.956  58.043  1.00  0.00           H  
+HETATM   18  H12 LIG   683      60.915  67.213  58.333  1.00  0.00           H  
+HETATM   19  H13 LIG   683      62.139  66.062  58.393  1.00  0.00           H  
+HETATM   20  H14 LIG   683      61.535  66.789  59.799  1.00  0.00           H  
+TER      21      LIG   683 
+CONECT    1    2    3   10   11
+CONECT    2    1    7    8    9
+CONECT    3    1    5   12   13
+CONECT    4    6   18   19   20
+CONECT    5    3    6   14   15
+CONECT    6    4    5   16   17
+CONECT    7    2
+CONECT    8    2
+CONECT    9    2
+CONECT   10    1
+CONECT   11    1
+CONECT   12    3
+CONECT   13    3
+CONECT   14    5
+CONECT   15    5
+CONECT   16    6
+CONECT   17    6
+CONECT   18    4
+CONECT   19    4
+CONECT   20    4
+END   

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -91,9 +91,9 @@ def test_loadall_pdb(molfile, natoms: int, nbonds: int) -> None:
     except NotImplementedError:  # PDBMolSupplier in RDkit is not supported
         pass  # TODO: Warning
 
+
 @pytest.mark.parametrize(
-    "molfile, natoms",
-    [("benzene.sdf", 12), ("ethanol.sdf", 9), ("dialanine.sdf", 23)],
+    "molfile, natoms", [("benzene.sdf", 12), ("ethanol.sdf", 9), ("dialanine.sdf", 23)],
 )
 def test_loadmol_sdf(molfile, natoms: int) -> None:
 
@@ -101,21 +101,25 @@ def test_loadmol_sdf(molfile, natoms: int) -> None:
 
     assert len(m) == natoms
 
+
 @pytest.mark.parametrize(
     "molfile, natoms", [("1cbr_ligand.mol2", 49)],
 )
-def test_load_mol2(molfile, natoms: int) -> None:
+def test_loadmol_mol2(molfile, natoms: int) -> None:
 
     m = io.loadmol(os.path.join(molpath, molfile))
 
     assert len(m) == natoms
 
-def test_loadall_sdf(molfile, natoms: int, nbonds: int) -> None:
+
+@pytest.mark.parametrize(
+    "molfile, natoms", [("1cbr_docking.sdf", 22)],
+)
+def test_loadallmols_sdf(molfile, natoms: int) -> None:
 
     ms = io.loadallmols(os.path.join(molpath, molfile))
 
     assert len(ms) == 10
 
     for m in ms:
-        assert io.numatoms(m) == natoms
-        assert io.numbonds(m) == nbonds
+        assert len(m) == natoms

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -89,4 +89,33 @@ def test_loadall_pdb(molfile, natoms: int, nbonds: int) -> None:
             assert io.numbonds(m) == nbonds
 
     except NotImplementedError:  # PDBMolSupplier in RDkit is not supported
-        pass  # Warning
+        pass  # TODO: Warning
+
+@pytest.mark.parametrize(
+    "molfile, natoms",
+    [("benzene.sdf", 12), ("ethanol.sdf", 9), ("dialanine.sdf", 23)],
+)
+def test_loadmol_sdf(molfile, natoms: int) -> None:
+
+    m = io.loadmol(os.path.join(molpath, molfile))
+
+    assert len(m) == natoms
+
+@pytest.mark.parametrize(
+    "molfile, natoms", [("1cbr_ligand.mol2", 49)],
+)
+def test_load_mol2(molfile, natoms: int) -> None:
+
+    m = io.loadmol(os.path.join(molpath, molfile))
+
+    assert len(m) == natoms
+
+def test_loadall_sdf(molfile, natoms: int, nbonds: int) -> None:
+
+    ms = io.loadallmols(os.path.join(molpath, molfile))
+
+    assert len(ms) == 10
+
+    for m in ms:
+        assert io.numatoms(m) == natoms
+        assert io.numbonds(m) == nbonds

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -90,6 +90,21 @@ def test_loadall_pdb(molfile, natoms: int, nbonds: int) -> None:
 
     except NotImplementedError:  # PDBMolSupplier in RDkit is not supported
         pass  # TODO: Warning
+def test_loadall_pdb_single_model() -> None:
+    """
+    Test load_all function for PDB files when only a single model is present.
+    """
+
+    try:
+        ms = io.loadall(os.path.join(molpath, "1a99_ligand.pdb"))
+
+        assert len(ms) == 1
+
+        assert io.numatoms(ms[0]) == 20
+        assert io.numbonds(ms[0]) == 19
+
+    except NotImplementedError:  # PDBMolSupplier in RDkit is not supported
+        pass  # TODO: Warning
 
 
 @pytest.mark.parametrize(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -90,6 +90,8 @@ def test_loadall_pdb(molfile, natoms: int, nbonds: int) -> None:
 
     except NotImplementedError:  # PDBMolSupplier in RDkit is not supported
         pass  # TODO: Warning
+
+
 def test_loadall_pdb_single_model() -> None:
     """
     Test load_all function for PDB files when only a single model is present.


### PR DESCRIPTION
## Description

Load molecules directly into a `spyrmsd.molecule.Molecule` object and fix problem with single-model PDB file when loaded with `spyrmsd.io.loadall`/`spyrmsd.io.loadallmols`.