### PR TITLE
Speedup computation of squared pairwise distances

### DIFF
--- a/spyrmsd/hungarian.py
+++ b/spyrmsd/hungarian.py
@@ -28,7 +28,7 @@ def cost_mtx(A: np.ndarray, B: np.ndarray):
         molecules A and B
     """
 
-    return scipy.spatial.distance.cdist(A, B) ** 2
+    return scipy.spatial.distance.cdist(A, B, metric='sqeuclidean')
 
 
 def optimal_assignment(A: np.ndarray, B: np.ndarray):


### PR DESCRIPTION
## Description

Fix #43 by using
```
scipy.spatial.distance.cdist(A, B, 'sqeuclidean')
```
instead of computing the euclidean distance (which involves `np.sqrt`) and taking the square.