### PR TITLE
OpenBabel and RDKit constructors

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -25,7 +25,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install mypy
-        mypy --install-types
+    - name: Install Types
+      run: |
+        python -m pip install types-requests
     - name: Install  package
       run: |
         python setup.py develop --no-deps

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install mypy
+        mypy --install-types
     - name: Install  package
       run: |
         python setup.py develop --no-deps

--- a/spyrmsd/hungarian.py
+++ b/spyrmsd/hungarian.py
@@ -28,7 +28,7 @@ def cost_mtx(A: np.ndarray, B: np.ndarray):
         molecules A and B
     """
 
-    return scipy.spatial.distance.cdist(A, B, metric='sqeuclidean')
+    return scipy.spatial.distance.cdist(A, B, metric="sqeuclidean")
 
 
 def optimal_assignment(A: np.ndarray, B: np.ndarray):

--- a/spyrmsd/molecule.py
+++ b/spyrmsd/molecule.py
@@ -55,6 +55,20 @@ class Molecule:
 
         self.masses: Optional[List[float]] = None
 
+    @classmethod
+    def from_obabel(cls, obmol, adjacency=True):
+        # TODO: Check if OpenBabel is available?
+        from spyrmsd.optional import obabel as ob
+
+        return ob.to_molecule(obmol, adjacency=adjacency)
+
+    @classmethod
+    def from_rdkit(cls, rdmol, adjacency=True):
+        # TODO: Check if OpenBabel is available?
+        from spyrmsd.optional import rdkit as rd
+
+        return rd.to_molecule(rdmol, adjacency=adjacency)
+
     def translate(self, vector: np.ndarray) -> None:
         """
         Translate molecule.

--- a/spyrmsd/molecule.py
+++ b/spyrmsd/molecule.py
@@ -113,7 +113,9 @@ class Molecule:
         vector = np.asarray(vector)
         self.coordinates += vector
 
-    def rotate(self, angle: float, axis: Union[np.ndarray, List[float]], units: str = "rad") -> None:
+    def rotate(
+        self, angle: float, axis: Union[np.ndarray, List[float]], units: str = "rad"
+    ) -> None:
         """
         Rotate molecule.
 

--- a/spyrmsd/molecule.py
+++ b/spyrmsd/molecule.py
@@ -56,15 +56,46 @@ class Molecule:
         self.masses: Optional[List[float]] = None
 
     @classmethod
-    def from_obabel(cls, obmol, adjacency=True):
+    def from_obabel(cls, obmol, adjacency: bool = True):
+        """
+        Constructor from OpenBabel molecule.
+
+        Parameters
+        ----------
+        obmol:
+            OpenBabel molecule
+        adjacency:
+            Flag to compute the adjacency matrix
+
+        Returns
+        -------
+        spyrmsd.molecule.Molecule
+            :code:`spyrmsd` Molecule
+        """
         # TODO: Check if OpenBabel is available?
         from spyrmsd.optional import obabel as ob
 
         return ob.to_molecule(obmol, adjacency=adjacency)
 
     @classmethod
-    def from_rdkit(cls, rdmol, adjacency=True):
-        # TODO: Check if OpenBabel is available?
+    def from_rdkit(cls, rdmol, adjacency: bool = True):
+        """
+        Constructor from RDKit molecule.
+
+        Parameters
+        ----------
+        rdmol:
+            RDKit molecule
+        adjacency:
+            Flag to compute the adjacency matrix
+
+        Returns
+        -------
+        spyrmsd.molecule.Molecule
+            :code:`spyrmsd` Molecule
+        """
+
+        # TODO: Check if RDKit is available?
         from spyrmsd.optional import rdkit as rd
 
         return rd.to_molecule(rdmol, adjacency=adjacency)

--- a/spyrmsd/optional/obabel.py
+++ b/spyrmsd/optional/obabel.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import numpy as np
 
@@ -120,10 +120,7 @@ def to_molecule(mol, adjacency: bool = True):
         atomicnums[i] = atom.atomicnum
         coordinates[i] = atom.coords
 
-    if adjacency:
-        A = adjacency_matrix(mol)
-    else:
-        A = None
+    A: Optional[np.ndarray] = adjacency_matrix(mol) if adjacency else None
 
     return molecule.Molecule(atomicnums, coordinates, A)
 

--- a/spyrmsd/optional/obabel.py
+++ b/spyrmsd/optional/obabel.py
@@ -122,6 +122,8 @@ def to_molecule(mol, adjacency: bool = True):
 
     if adjacency:
         A = adjacency_matrix(mol)
+    else:
+        A = None
 
     return molecule.Molecule(atomicnums, coordinates, A)
 

--- a/spyrmsd/optional/rdkit.py
+++ b/spyrmsd/optional/rdkit.py
@@ -120,6 +120,8 @@ def to_molecule(mol, adjacency: bool = True):
 
     if adjacency:
         A = adjacency_matrix(mol)
+    else:
+        A = None
 
     return molecule.Molecule(atomicnums, coordinates, A)
 

--- a/spyrmsd/optional/rdkit.py
+++ b/spyrmsd/optional/rdkit.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import numpy as np
 import rdkit.Chem as Chem
@@ -118,10 +118,7 @@ def to_molecule(mol, adjacency: bool = True):
 
         coordinates[i] = np.array([pos.x, pos.y, pos.z])
 
-    if adjacency:
-        A = adjacency_matrix(mol)
-    else:
-        A = None
+    A: Optional[np.ndarray] = adjacency_matrix(mol) if adjacency else None
 
     return molecule.Molecule(atomicnums, coordinates, A)
 

--- a/spyrmsd/utils.py
+++ b/spyrmsd/utils.py
@@ -82,7 +82,9 @@ def deg_to_rad(angle: float) -> float:
     return angle * np.pi / 180.0
 
 
-def rotate(v: np.ndarray, angle: float, axis: np.ndarray, units: str = "rad") -> np.ndarray:
+def rotate(
+    v: np.ndarray, angle: float, axis: np.ndarray, units: str = "rad"
+) -> np.ndarray:
     """
     Rotate vector.
 

--- a/spyrmsd/utils.py
+++ b/spyrmsd/utils.py
@@ -82,7 +82,7 @@ def deg_to_rad(angle: float) -> float:
     return angle * np.pi / 180.0
 
 
-def rotate(v: np.array, angle: float, axis: np.array, units: str = "rad") -> np.array:
+def rotate(v: np.ndarray, angle: float, axis: np.ndarray, units: str = "rad") -> np.ndarray:
     """
     Rotate vector.
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -30,7 +30,7 @@ def test_adjacency_matrix_from_mol(mol) -> None:
     A = io.adjacency_matrix(mol)
 
     assert A.shape == (natoms, natoms)
-    assert np.alltrue(A == A.T)
+    assert np.all(A == A.T)
     assert np.sum(A) == nbonds * 2
 
     for i, j in io.bonds(mol):
@@ -47,7 +47,7 @@ def test_graph_from_adjacency_matrix(mol) -> None:
     A = io.adjacency_matrix(mol)
 
     assert A.shape == (natoms, natoms)
-    assert np.alltrue(A == A.T)
+    assert np.all(A == A.T)
     assert np.sum(A) == nbonds * 2
 
     G = graph.graph_from_adjacency_matrix(A)
@@ -68,7 +68,7 @@ def test_graph_from_adjacency_matrix_atomicnums(rawmol, mol) -> None:
 
     assert len(mol) == natoms
     assert mol.adjacency_matrix.shape == (natoms, natoms)
-    assert np.alltrue(mol.adjacency_matrix == A)
+    assert np.all(mol.adjacency_matrix == A)
     assert np.sum(mol.adjacency_matrix) == nbonds * 2
 
     G = mol.to_graph()

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -194,3 +194,37 @@ def test_graph_from_atomic_coordinates_perception(
 
         for idx, atomicnum in enumerate(mol.atomicnums):
             assert graph.vertex_property(G, "atomicnum", idx) == atomicnum
+
+
+def test_from_obmol():
+    pytest.importorskip("openbabel")
+
+    from spyrmsd.optional import obabel as ob
+
+    # Load molecules with OpenBabel
+    path = os.path.join(molecules.molpath, "1cbr_docking.sdf")
+    mols = ob.loadall(path)
+
+    # Convert OpenBabel molecules to spyrmsd molecules
+    mols = [molecule.Molecule.from_obabel(mol) for mol in mols]
+
+    assert len(mols) == 10
+    for mol in mols:
+        assert isinstance(mol, molecule.Molecule)
+
+
+def test_from_rdmol():
+    pytest.importorskip("rdkit")
+
+    from spyrmsd.optional import rdkit as rd
+
+    # Load molecules with RDKit
+    path = os.path.join(molecules.molpath, "1cbr_docking.sdf")
+    mols = rd.loadall(path)
+
+    # Convert OpenBabel molecules to spyrmsd molecules
+    mols = [molecule.Molecule.from_rdkit(mol) for mol in mols]
+
+    assert len(mols) == 10
+    for mol in mols:
+        assert isinstance(mol, molecule.Molecule)

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -115,7 +115,7 @@ def test_molecule_center_of_mass_benzene() -> None:
 def test_molecule_center_of_mass_H2() -> None:
 
     atomicnums = [1, 1]
-    coordinates = [[0., 0., -1.], [0., 0., 1.]]
+    coordinates = [[0.0, 0.0, -1.0], [0.0, 0.0, 1.0]]
 
     mol = molecule.Molecule(atomicnums, coordinates)
 
@@ -125,7 +125,7 @@ def test_molecule_center_of_mass_H2() -> None:
 def test_molecule_center_of_mass_HF() -> None:
 
     atomicnums = [1, 9]
-    coordinates = [[0., 0., -1.], [0., 0., 1.]]
+    coordinates = [[0.0, 0.0, -1.0], [0.0, 0.0, 1.0]]
 
     H_mass = qcel.periodictable.to_mass(1)
     F_mass = qcel.periodictable.to_mass(9)

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -196,7 +196,10 @@ def test_graph_from_atomic_coordinates_perception(
             assert graph.vertex_property(G, "atomicnum", idx) == atomicnum
 
 
-def test_from_obmol():
+@pytest.mark.parametrize(
+    "adjacency", [True, False],
+)
+def test_from_obmol(adjacency):
     pytest.importorskip("openbabel")
 
     from spyrmsd.optional import obabel as ob
@@ -206,14 +209,25 @@ def test_from_obmol():
     mols = ob.loadall(path)
 
     # Convert OpenBabel molecules to spyrmsd molecules
-    mols = [molecule.Molecule.from_obabel(mol) for mol in mols]
+    mols = [molecule.Molecule.from_obabel(mol, adjacency) for mol in mols]
 
     assert len(mols) == 10
+
     for mol in mols:
         assert isinstance(mol, molecule.Molecule)
 
+        if adjacency:
+            assert mol.adjacency_matrix is not None
+        else:
+            with pytest.raises(AttributeError):
+                # No adjacency_matrix attribute
+                mol.adjacency_matrix
 
-def test_from_rdmol():
+
+@pytest.mark.parametrize(
+    "adjacency", [True, False],
+)
+def test_from_rdmol(adjacency):
     pytest.importorskip("rdkit")
 
     from spyrmsd.optional import rdkit as rd
@@ -223,8 +237,16 @@ def test_from_rdmol():
     mols = rd.loadall(path)
 
     # Convert OpenBabel molecules to spyrmsd molecules
-    mols = [molecule.Molecule.from_rdkit(mol) for mol in mols]
+    mols = [molecule.Molecule.from_rdkit(mol, adjacency) for mol in mols]
 
     assert len(mols) == 10
+
     for mol in mols:
         assert isinstance(mol, molecule.Molecule)
+
+        if adjacency:
+            assert mol.adjacency_matrix is not None
+        else:
+            with pytest.raises(AttributeError):
+                # No adjacency_matrix attribute
+                mol.adjacency_matrix

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -115,7 +115,7 @@ def test_molecule_center_of_mass_benzene() -> None:
 def test_molecule_center_of_mass_H2() -> None:
 
     atomicnums = [1, 1]
-    coordinates = [[0, 0, -1], [0, 0, 1]]
+    coordinates = [[0., 0., -1.], [0., 0., 1.]]
 
     mol = molecule.Molecule(atomicnums, coordinates)
 
@@ -125,7 +125,7 @@ def test_molecule_center_of_mass_H2() -> None:
 def test_molecule_center_of_mass_HF() -> None:
 
     atomicnums = [1, 9]
-    coordinates = [[0, 0, -1], [0, 0, 1]]
+    coordinates = [[0., 0., -1.], [0., 0., 1.]]
 
     H_mass = qcel.periodictable.to_mass(1)
     F_mass = qcel.periodictable.to_mass(9)
@@ -181,7 +181,7 @@ def test_graph_from_atomic_coordinates_perception(
 
     m = copy.deepcopy(mol)
 
-    m.adjacency_matrix = None
+    delattr(m, "adjacency_matrix")
     m.G = None
 
     with pytest.warns(UserWarning):


### PR DESCRIPTION
## Description

Fix #41; it is now possible to build a `spyrmsd.molecule.Molecule` directly from an OpenBabel or RDKit molecules.

This PR also solves a unreported problem where `to_molecule` would fail with `adjacency=False` (which was not tested).

Some changes are introduced for compatibility with the latest version of `mypy`.

## Checklist

- [x] Tests
- [x] Documentation