### PR TITLE
Allow RMSD wrapper to deal with single molecule

### DIFF
--- a/spyrmsd/optional/obabel.py
+++ b/spyrmsd/optional/obabel.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 

--- a/spyrmsd/optional/rdkit.py
+++ b/spyrmsd/optional/rdkit.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 import rdkit.Chem as Chem

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -55,7 +55,7 @@ def rmsdwrapper(
     ----------
     molref: molecule.Molecule
         Reference molecule
-    mols: molecule.Molecule
+    mols: Union[molecule.Molecule, List[molecule.Molecule]]
         Molecules to compare to reference molecule
     symmetry: bool, optional
         Symmetry-corrected RMSD (using graph isomorphism)

--- a/spyrmsd/spyrmsd.py
+++ b/spyrmsd/spyrmsd.py
@@ -2,7 +2,7 @@
 Python RMSD tool
 """
 
-from typing import Any
+from typing import Any, List, Union
 
 import numpy as np
 
@@ -40,8 +40,8 @@ def coords_from_molecule(mol: molecule.Molecule, center: bool = False) -> np.nda
 
 
 def rmsdwrapper(
-    molref,
-    mols,
+    molref: molecule.Molecule,
+    mols: Union[molecule.Molecule, List[molecule.Molecule]],
     symmetry: bool = True,
     center: bool = False,
     minimize: bool = False,
@@ -53,10 +53,10 @@ def rmsdwrapper(
 
     Parameters
     ----------
-    mol1: molecule.Molecule
-        Molecule 1
-    mol2: molecule.Molecule
-        Molecule 2
+    molref: molecule.Molecule
+        Reference molecule
+    mols: molecule.Molecule
+        Molecules to compare to reference molecule
     symmetry: bool, optional
         Symmetry-corrected RMSD (using graph isomorphism)
     center: bool, optional
@@ -71,6 +71,9 @@ def rmsdwrapper(
     List[float]
         RMSDs
     """
+
+    if not isinstance(mols, list):
+        mols = [mols]
 
     if strip:
         molref.strip()

--- a/tests/test_spyrmsd.py
+++ b/tests/test_spyrmsd.py
@@ -109,7 +109,7 @@ def test_rmsdwrapper_isomorphic(minimize: bool, referenceRMSDs: List[float]) -> 
 @pytest.mark.parametrize(
     # Reference results obtained with OpenBabel
     "minimize, referenceRMSD",
-    [(True, 0.476858,), (False, 0.592256,),],
+    [(True, 0.476858), (False, 0.592256)],
 )
 def test_rmsdwrapper_single_molecule(minimize: bool, referenceRMSD: float) -> None:
 

--- a/tests/test_spyrmsd.py
+++ b/tests/test_spyrmsd.py
@@ -104,3 +104,18 @@ def test_rmsdwrapper_isomorphic(minimize: bool, referenceRMSDs: List[float]) -> 
 
     for RMSD, referenceRMSD in zip(RMSDs, referenceRMSDs):
         assert RMSD == pytest.approx(referenceRMSD, abs=1e-5)
+
+
+@pytest.mark.parametrize(
+    # Reference results obtained with OpenBabel
+    "minimize, referenceRMSD",
+    [(True, 0.476858,), (False, 0.592256,),],
+)
+def test_rmsdwrapper_single_molecule(minimize: bool, referenceRMSD: float) -> None:
+
+    molref = copy.deepcopy(molecules.docking_1cbr[0])
+    mols = copy.deepcopy(molecules.docking_1cbr[1])
+
+    rmsd = spyrmsd.rmsdwrapper(molref, mols, minimize=minimize, strip=True)
+
+    assert rmsd[0] == pytest.approx(referenceRMSD, abs=1e-5)


### PR DESCRIPTION
## Description

Allow wrapper to deal with single molecule as input, instead of supporting only a list of molecules. Fix #48.

## Checklist

- [x] Tests
- [x] Documentation