### PR TITLE
Add pre-commit configuration file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    - id: check-json
+    - id: check-merge-conflict
+    - id: check-yaml
+    - id: check-toml
+    - id: debug-statements
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+    -   id: black
+-   repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
+    hooks:
+    -   id: isort
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+    -   id: mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors:    @RMeli
 
 ### Added
 
+* Added [pre-commit](https://pre-commit.com/) configuration file [PR #57 | @RMeli]
 * Added support for gzip-compressed files (`.gz`) [PR #56 | @RMeli]
 
 ## Version 0.5.0

--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ To ensure code quality and consistency the following tools are used during devel
 
 * [black](https://black.readthedocs.io/en/stable/)
 * [Flake 8](http://flake8.pycqa.org/en/latest/) (CI)
+* [isort]()
 * [mypy](http://mypy-lang.org/) (CI)
+
+Pre-commit `git` hooks can be installed with [pre-commit](https://pre-commit.com/).
 
 ## Copyright
 


### PR DESCRIPTION
## Description

Add [pre-commit](https://pre-commit.com/) configuration file. This allows to install pre-commit `git` hooks (`pre-commit install`) so that every commit runs the same checks as CI (`black`, `flake8`, `isort`, `mypy`).

## Checklist

- [x] Documentation
- [x] Changelog
