### PR TITLE
Fix number of nodes in graph-tool graphs with disconnected single nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 
 ------------------------------------------------------------------------------
 
+## Version 0.5.x
+
+Date:            XX/YY/20ZZ
+Contributors:    @RMeli
+
+### Fixed
+
+* Fixed inconsistent number of nodes with `graph-tool` for disconnected graphs [ | @RMeli]
+
+### Added
+
+* Warning for disconnected graphs [ | @RMeli]
+
+------------------------------------------------------------------------------
+
 ## Version 0.5.1
 
 Date:            21/09/2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ Contributors:    @RMeli
 
 ### Fixed
 
-* Fixed inconsistent number of nodes with `graph-tool` for disconnected graphs [ | @RMeli]
+* Fixed inconsistent number of nodes with `graph-tool` for disconnected graphs [PR #61 | @RMeli]
 
 ### Added
 
-* Warning for disconnected graphs [ | @RMeli]
+* Warning for disconnected graphs [PR #61| @RMeli]
 
 ------------------------------------------------------------------------------
 

--- a/spyrmsd/graphs/gt.py
+++ b/spyrmsd/graphs/gt.py
@@ -37,6 +37,7 @@ def graph_from_adjacency_matrix(
     G.add_edge_list(np.transpose(adj.nonzero()))
 
     if atomicnums is not None:
+        # TODO: Support more Python types
         vprop = G.new_vertex_property("short")  # Create property map (of C type short)
         vprop.a = atomicnums  # Assign atomic numbers to property map array
         G.vertex_properties["atomicnum"] = vprop  # Set property map

--- a/spyrmsd/graphs/gt.py
+++ b/spyrmsd/graphs/gt.py
@@ -33,7 +33,11 @@ def graph_from_adjacency_matrix(
     # Get upper triangular adjacency matrix
     adj = np.triu(adjacency_matrix)
 
+    assert adj.shape[0] == adj.shape[1]
+    num_vertices = adj.shape[0]
+
     G = gt.Graph(directed=False)
+    G.add_vertex(n=num_vertices)
     G.add_edge_list(np.transpose(adj.nonzero()))
 
     if atomicnums is not None:

--- a/spyrmsd/graphs/gt.py
+++ b/spyrmsd/graphs/gt.py
@@ -40,6 +40,11 @@ def graph_from_adjacency_matrix(
     G.add_vertex(n=num_vertices)
     G.add_edge_list(np.transpose(adj.nonzero()))
 
+    # Check if graph is connected, for warning
+    cc, _ = topology.label_components(G)
+    if set(cc.a) != {0}:
+        warnings.warn("Disconnected graph detected. Is this expected?")
+
     if atomicnums is not None:
         # TODO: Support more Python types
         vprop = G.new_vertex_property("short")  # Create property map (of C type short)

--- a/spyrmsd/graphs/nx.py
+++ b/spyrmsd/graphs/nx.py
@@ -31,6 +31,9 @@ def graph_from_adjacency_matrix(
 
     G = nx.Graph(adjacency_matrix)
 
+    if not G.is_connected():
+        warnings.warn("Disconnected graph detected. Is this expected?")
+
     if atomicnums is not None:
         attributes = {idx: atomicnum for idx, atomicnum in enumerate(atomicnums)}
         nx.set_node_attributes(G, attributes, "atomicnum")

--- a/spyrmsd/graphs/nx.py
+++ b/spyrmsd/graphs/nx.py
@@ -31,7 +31,7 @@ def graph_from_adjacency_matrix(
 
     G = nx.Graph(adjacency_matrix)
 
-    if not G.is_connected():
+    if not nx.is_connected(G):
         warnings.warn("Disconnected graph detected. Is this expected?")
 
     if atomicnums is not None:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -109,7 +109,9 @@ def test_graph_from_adjacency_matrix_atomicnums(rawmol, mol) -> None:
 )
 def test_match_graphs_isomorphic(G1, G2) -> None:
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(
+        UserWarning, match="No atomic number information stored on nodes."
+    ):
         isomorphisms = graph.match_graphs(G1, G2)
 
     assert len(isomorphisms) != 0
@@ -124,5 +126,7 @@ def test_match_graphs_isomorphic(G1, G2) -> None:
 )
 def test_match_graphs_not_isomorphic(G1, G2) -> None:
 
-    with pytest.raises(ValueError), pytest.warns(UserWarning):
+    with pytest.raises(ValueError, match="Graphs are not isomorphic."), pytest.warns(
+        UserWarning, match="No atomic number information stored on nodes."
+    ):
         graph.match_graphs(G1, G2)

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -520,6 +520,17 @@ def test_rmsd_symmrmsd(index: int, RMSD: float, minimize: bool) -> None:
     )
 
 
+def test_rmsd_symmrmsd_disconnected_node() -> None:
+
+    c = np.array([[0.0, 1.0, 2.0], [1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])
+    a = np.array([0, 1, 4])
+
+    # Adjacency matrix with disconnected node
+    A = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
+
+    assert rmsd.symmrmsd(c, c, a, a, A, A) == pytest.approx(0.0, abs=1e-5)
+
+
 # Results obtained with OpenBabel
 @pytest.mark.parametrize(
     "minimize, referenceRMSDs",

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -528,7 +528,8 @@ def test_rmsd_symmrmsd_disconnected_node() -> None:
     # Adjacency matrix with disconnected node
     A = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
 
-    assert rmsd.symmrmsd(c, c, a, a, A, A) == pytest.approx(0.0, abs=1e-5)
+    with pytest.warns(UserWarning, match="Disconnected graph detected."):
+        assert rmsd.symmrmsd(c, c, a, a, A, A) == pytest.approx(0.0, abs=1e-5)
 
 
 # Results obtained with OpenBabel


### PR DESCRIPTION
## Description

Fix #61 by explicitly defining the number of vertices when creating a `graph-tool` graph from an adjacency matrix.

This PR also add a warning for disconnected graphs, but might slowing down things for something that is not really useful in standard cases (i.e. small molecules).

## Checklist

- [x] Tests
- [x] Changelog
