### PR TITLE
Expand node attribute types for graph-tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Contributors:    @RMeli
 
 ### Fixed
 
-* Fixed inconsistent number of nodes with `graph-tool` for disconnected graphs [PR #61 | @RMeli]
+* Inconsistent number of nodes with `graph-tool` for disconnected graphs [PR #61 | @RMeli]
+
+### Improved
+
+* Support for more types of node properties (including strings) with `graph-tool` [PR # | @RMeli]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Contributors:    @RMeli
 
 ### Improved
 
-* Support for more types of node properties (including strings) with `graph-tool` [PR # | @RMeli]
+* Support for more types of node properties (including strings) with `graph-tool` [PR #64 | @RMeli]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,16 +25,16 @@ Contributors:    @RMeli
 
 ### Fixed
 
-* Fixed wrong covalent radius in `graph.adjacency_matrix_from_atomic_coordinates()` [PR #58 | @RMeli]
+* Wrong covalent radius in `graph.adjacency_matrix_from_atomic_coordinates()` [PR #58 | @RMeli]
 
 ### Added
 
-* Added [pre-commit](https://pre-commit.com/) configuration file [PR #57 | @RMeli]
-* Added support for gzip-compressed files (`.gz`) [PR #56 | @RMeli]
+* [pre-commit](https://pre-commit.com/) configuration file [PR #57 | @RMeli]
+* Support for gzip-compressed files (`.gz`) [PR #56 | @RMeli]
 
 ### Removed
 
-* Removed dependency `QCElemental` [PR #58 | @RMeli]
+* Dependency `QCElemental` [PR #58 | @RMeli]
 
 ------------------------------------------------------------------------------
 
@@ -46,15 +46,15 @@ Contributors:    @RMeli
 
 ### Added
 
-* Added `molecule.Molecule` constructor from RDKit molecule [PR #50 | @RMeli]
-* Added `molecule.Molecule` constructor from Open Babel molecule [PR #50 | @RMeli]
-* Added `--n-tests` option for `pytest` [PR #44 | @RMeli]
+* `molecule.Molecule` constructor from RDKit molecule [PR #50 | @RMeli]
+* `molecule.Molecule` constructor from Open Babel molecule [PR #50 | @RMeli]
+* `--n-tests` option for `pytest` [PR #44 | @RMeli]
 
 ### Improved
 
-* Improved `spyrmsd.rmsdwrapper` to deal with single molecule [PR #51 | @RMeli]
-* Improved issue template [PR #46 | @RMeli]
-* Improved speed of computation of squared pairwise distances [PR #45 | @RMeli]
+* `spyrmsd.rmsdwrapper` to deal with single molecule [PR #51 | @RMeli]
+* Issue template [PR #46 | @RMeli]
+* Speed of computation of squared pairwise distances [PR #45 | @RMeli]
 
 ### Changed
 
@@ -65,8 +65,8 @@ Contributors:    @RMeli
 
 ### Removed
 
-* Removed `spyrmsd` module [PR #52 | @RMeli]
-* Removed Travis CI and AppVeyor bindings [PR #44 | @RMeli]
-* Removed `--long` option for `pytest` [PR #44 | @RMeli]
+* `spyrmsd` module [PR #52 | @RMeli]
+* Travis CI and AppVeyor bindings [PR #44 | @RMeli]
+* `--long` option for `pytest` [PR #44 | @RMeli]
 
 ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -122,13 +122,15 @@ The function  `rmsd.rmsd` computes RMSD without symmetry correction. The atoms a
 def rmsd(
     coords1: np.ndarray,    # Coordinates of molecule 1
     coords2: np.ndarray,    # Coordinates of molecule 2
-    atomicn1: np.ndarray,   # Atomic number of molecule 1
-    atomicn2: np.ndarray,   # Atomic number of molecule 2
+    aprops1: np.ndarray,    # Atomic properties of molecule 1
+    aprops2: np.ndarray,    # Atomic properties of molecule 2
     center: bool = False,   # Flag to center molecules at origin
     minimize: bool = False, # Flag to compute minimum RMSD
     atol: float = 1e-9,     # Numerical tolerance for QCP method
 )
 ```
+
+Note: atomic properties (`aprops`) can be any Python object when using [NetworkX](https://networkx.github.io/), or integers, floats, or strings when using [graph-tool](https://graph-tool.skewed.de/).
 
 #### Symmetry-Corrected RMSD
 
@@ -140,8 +142,8 @@ Atom matching is performed according to the molecular graph. This function shoul
 def symmrmsd(
     coordsref: np.ndarray,                       # Reference coordinated
     coords: Union[np.ndarray, List[np.ndarray]], # Coordinates (one set or multiple sets)
-    atomicnumsref: np.ndarray,                   # Reference atomic numbers
-    atomicnums: np.ndarray,                      # Atomic numbers
+    apropsref: np.ndarray,                       # Reference atomic properties
+    aprops: np.ndarray,                          # Atomic properties
     amref: np.ndarray,                           # Reference adjacency matrix
     am: np.ndarray,                              # Adjacency matrix
     center: bool = False,                        # Flag to center molecules at origin
@@ -150,6 +152,8 @@ def symmrmsd(
     atol: float = 1e-9,                          # Numerical tolerance for QCP method
 )
 ```
+
+Note: atomic properties (`aprops`) can be any Python object when using [NetworkX](https://networkx.github.io/), or integers, floats, or strings when using [graph-tool](https://graph-tool.skewed.de/).
 
 ## Development
 

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -40,15 +40,15 @@ from spyrmsd import constants
 
 
 def adjacency_matrix_from_atomic_coordinates(
-    atomicnums: np.ndarray, coordinates: np.ndarray
+    aprops: np.ndarray, coordinates: np.ndarray
 ) -> np.ndarray:
     """
     Compute adjacency matrix from atomic coordinates.
 
     Parameters
     ----------
-    atomicnums: numpy.ndarray
-        Atomic numbers
+    aprops: numpy.ndarray
+        Atomic properties
     coordinates: numpy.ndarray
         Atomic coordinates
 
@@ -74,17 +74,17 @@ def adjacency_matrix_from_atomic_coordinates(
        (1991).
     """
 
-    n = len(atomicnums)
+    n = len(aprops)
 
     assert coordinates.shape == (n, 3)
 
     A = np.zeros((n, n))
 
     for i in range(n):
-        r_i = constants.anum_to_covalentradius[atomicnums[i]]
+        r_i = constants.anum_to_covalentradius[aprops[i]]
 
         for j in range(i + 1, n):
-            r_j = constants.anum_to_covalentradius[atomicnums[j]]
+            r_j = constants.anum_to_covalentradius[aprops[j]]
 
             distance = np.sqrt(np.sum((coordinates[i] - coordinates[j]) ** 2))
 

--- a/spyrmsd/graphs/_common.py
+++ b/spyrmsd/graphs/_common.py
@@ -1,0 +1,8 @@
+warn_disconnected_graph: str = "Disconnected graph detected. Is this expected?"
+warn_no_atomic_properties: str = (
+    "No atomic property information stored on nodes. Node matching is not performed..."
+)
+
+error_non_isomorphic_graphs: str = (
+    "Graphs are not isomorphic.\nMake sure graphs have the same connectivity."
+)

--- a/spyrmsd/graphs/gt.py
+++ b/spyrmsd/graphs/gt.py
@@ -5,6 +5,12 @@ import graph_tool as gt
 import numpy as np
 from graph_tool import generation, topology
 
+from spyrmsd.graphs._common import (
+    error_non_isomorphic_graphs,
+    warn_disconnected_graph,
+    warn_no_atomic_properties,
+)
+
 
 # TODO: Implement all graph-tool supported types
 def _c_type(numpy_dtype):
@@ -74,7 +80,7 @@ def graph_from_adjacency_matrix(
     # Check if graph is connected, for warning
     cc, _ = topology.label_components(G)
     if set(cc.a) != {0}:
-        warnings.warn("Disconnected graph detected. Is this expected?")
+        warnings.warn(warn_disconnected_graph)
 
     if aprops is not None:
         if not isinstance(aprops, np.ndarray):
@@ -122,20 +128,14 @@ def match_graphs(G1, G2) -> List[Tuple[List[int], List[int]]]:
             subgraph=False,
         )
     except KeyError:
-        warnings.warn(
-            "No atomic property information stored on nodes. "
-            + "Node matching is not performed..."
-        )
+        warnings.warn(warn_no_atomic_properties)
 
         maps = topology.subgraph_isomorphism(G1, G2, subgraph=False)
 
     # Check if graphs are actually isomorphic
     if len(maps) == 0:
         # TODO: Create a new exception
-        raise ValueError(
-            "Graphs are not isomorphic."
-            "\nMake sure graphs have the same connectivity."
-        )
+        raise ValueError(error_non_isomorphic_graphs)
 
     n = num_vertices(G1)
 

--- a/spyrmsd/graphs/gt.py
+++ b/spyrmsd/graphs/gt.py
@@ -39,7 +39,7 @@ def _c_type(numpy_dtype):
 
 def graph_from_adjacency_matrix(
     adjacency_matrix: Union[np.ndarray, List[List[int]]],
-    atomicnums: Optional[Union[np.ndarray, List[int]]] = None,
+    aprops: Optional[Union[np.ndarray, List[Any]]] = None,
 ):
     """
     Graph from adjacency matrix.
@@ -48,8 +48,8 @@ def graph_from_adjacency_matrix(
     ----------
     adjacency_matrix: Union[np.ndarray, List[List[int]]]
         Adjacency matrix
-    atomicnums: Union[np.ndarray, List[int]], optional
-        Atomic numbers
+    aprops: Union[np.ndarray, List[Any]], optional
+        Atomic properties
 
     Returns
     -------
@@ -76,15 +76,15 @@ def graph_from_adjacency_matrix(
     if set(cc.a) != {0}:
         warnings.warn("Disconnected graph detected. Is this expected?")
 
-    if atomicnums is not None:
-        if not isinstance(atomicnums, np.ndarray):
-            atomicnums = np.array(atomicnums)
+    if aprops is not None:
+        if not isinstance(aprops, np.ndarray):
+            aprops = np.array(aprops)
 
-        assert atomicnums.shape[0] == num_vertices
+        assert aprops.shape[0] == num_vertices
 
-        ptype: str = _c_type(atomicnums.dtype)  # Get C type
-        vprop = G.new_vertex_property(ptype, vals=atomicnums)  # Create property map
-        G.vertex_properties["atomicnum"] = vprop  # Set property map
+        ptype: str = _c_type(aprops.dtype)  # Get C type
+        vprop = G.new_vertex_property(ptype, vals=aprops)  # Create property map
+        G.vertex_properties["aprops"] = vprop  # Set property map
 
     return G
 
@@ -116,14 +116,14 @@ def match_graphs(G1, G2) -> List[Tuple[List[int], List[int]]]:
             G1,
             G2,
             vertex_label=(
-                G1.vertex_properties["atomicnum"],
-                G2.vertex_properties["atomicnum"],
+                G1.vertex_properties["aprops"],
+                G2.vertex_properties["aprops"],
             ),
             subgraph=False,
         )
-    except KeyError:  # No "atomicnum" vertex property
+    except KeyError:
         warnings.warn(
-            "No atomic number information stored on nodes. "
+            "No atomic property information stored on nodes. "
             + "Node matching is not performed..."
         )
 

--- a/spyrmsd/graphs/nx.py
+++ b/spyrmsd/graphs/nx.py
@@ -4,6 +4,12 @@ from typing import Any, List, Optional, Tuple, Union
 import networkx as nx
 import numpy as np
 
+from spyrmsd.graphs._common import (
+    error_non_isomorphic_graphs,
+    warn_disconnected_graph,
+    warn_no_atomic_properties,
+)
+
 
 def graph_from_adjacency_matrix(
     adjacency_matrix: Union[np.ndarray, List[List[int]]],
@@ -32,7 +38,7 @@ def graph_from_adjacency_matrix(
     G = nx.Graph(adjacency_matrix)
 
     if not nx.is_connected(G):
-        warnings.warn("Disconnected graph detected. Is this expected?")
+        warnings.warn(warn_disconnected_graph)
 
     if aprops is not None:
         attributes = {idx: aprops for idx, aprops in enumerate(aprops)}
@@ -77,10 +83,7 @@ def match_graphs(G1, G2) -> List[Tuple[List[int], List[int]]]:
         # No node-matching check
         node_match = None
 
-        warnings.warn(
-            "No atomic number information stored on nodes. "
-            + "Node matching is not performed..."
-        )
+        warnings.warn(warn_no_atomic_properties)
 
     else:
         node_match = match_aprops
@@ -90,10 +93,7 @@ def match_graphs(G1, G2) -> List[Tuple[List[int], List[int]]]:
     # Check if graphs are actually isomorphic
     if not GM.is_isomorphic():
         # TODO: Create a new exception
-        raise ValueError(
-            "Graphs are not isomorphic."
-            "\nMake sure graphs have the same connectivity."
-        )
+        raise ValueError(error_non_isomorphic_graphs)
 
     return [
         (list(isomorphism.keys()), list(isomorphism.values()))

--- a/spyrmsd/graphs/nx.py
+++ b/spyrmsd/graphs/nx.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def graph_from_adjacency_matrix(
     adjacency_matrix: Union[np.ndarray, List[List[int]]],
-    atomicnums: Optional[Union[np.ndarray, List[int]]] = None,
+    aprops: Optional[Union[np.ndarray, List[Any]]] = None,
 ) -> nx.Graph:
     """
     Graph from adjacency matrix.
@@ -16,8 +16,8 @@ def graph_from_adjacency_matrix(
     ----------
     adjacency_matrix: Union[np.ndarray, List[List[int]]]
         Adjacency matrix
-    atomicnums: Union[np.ndarray, List[int]], optional
-        Atomic numbers
+    aprops: Union[np.ndarray, List[Any]], optional
+        Atomic properties
 
     Returns
     -------
@@ -34,9 +34,9 @@ def graph_from_adjacency_matrix(
     if not nx.is_connected(G):
         warnings.warn("Disconnected graph detected. Is this expected?")
 
-    if atomicnums is not None:
-        attributes = {idx: atomicnum for idx, atomicnum in enumerate(atomicnums)}
-        nx.set_node_attributes(G, attributes, "atomicnum")
+    if aprops is not None:
+        attributes = {idx: aprops for idx, aprops in enumerate(aprops)}
+        nx.set_node_attributes(G, attributes, "aprops")
 
     return G
 
@@ -63,12 +63,15 @@ def match_graphs(G1, G2) -> List[Tuple[List[int], List[int]]]:
         If the graphs `G1` and `G2` are not isomorphic
     """
 
-    def match_atomicnum(node1, node2):
-        return node1["atomicnum"] == node2["atomicnum"]
+    def match_aprops(node1, node2):
+        """
+        Check if atomic properties for two nodes match.
+        """
+        return node1["aprops"] == node2["aprops"]
 
     if (
-        nx.get_node_attributes(G1, "atomicnum") == {}
-        or nx.get_node_attributes(G2, "atomicnum") == {}
+        nx.get_node_attributes(G1, "aprops") == {}
+        or nx.get_node_attributes(G2, "aprops") == {}
     ):
         # Nodes without atomic number information
         # No node-matching check
@@ -80,7 +83,7 @@ def match_graphs(G1, G2) -> List[Tuple[List[int], List[int]]]:
         )
 
     else:
-        node_match = match_atomicnum
+        node_match = match_aprops
 
     GM = nx.algorithms.isomorphism.GraphMatcher(G1, G2, node_match)
 

--- a/spyrmsd/hungarian.py
+++ b/spyrmsd/hungarian.py
@@ -61,7 +61,7 @@ def optimal_assignment(A: np.ndarray, B: np.ndarray):
 
 
 def hungarian_rmsd(
-    A: np.ndarray, B: np.ndarray, atomicnumsA: np.ndarray, atomicnumsB: np.ndarray
+    A: np.ndarray, B: np.ndarray, apropsA: np.ndarray, apropsB: np.ndarray
 ) -> float:
     """
     Solve the optimal assignment problems between atomic coordinates of
@@ -73,10 +73,10 @@ def hungarian_rmsd(
         Atomic coordinates of molecule A
     B: numpy.ndarray
         Atomic coordinates of molecule B
-    atomicnumsA: numpy.ndarray
-        Atomic numbers of molecule A
-    atomicnumsB: numpy.ndarray
-        Atomic numbers of molecule B
+    apropsA: numpy.ndarray
+        Atomic properties of molecule A
+    apropsB: numpy.ndarray
+        Atomic properties of molecule B
 
     Returns
     -------
@@ -96,19 +96,19 @@ def hungarian_rmsd(
     """
 
     assert A.shape == B.shape
-    assert atomicnumsA.shape == atomicnumsB.shape
+    assert apropsA.shape == apropsB.shape
 
-    elements = set(atomicnumsA)
+    elements = set(apropsA)
 
     total_cost: float = 0.0
     for t in elements:
-        atomicnumsA_idx = atomicnumsA == t
-        atomicnumsB_idx = atomicnumsB == t
+        apropsA_idx = apropsA == t
+        apropsB_idx = apropsB == t
 
-        assert atomicnumsA_idx.shape == atomicnumsB_idx.shape
+        assert apropsA_idx.shape == apropsB_idx.shape
 
         cost, row_idx, col_idx = optimal_assignment(
-            A[atomicnumsA_idx, :], B[atomicnumsB_idx, :]
+            A[apropsA_idx, :], B[apropsB_idx, :]
         )
 
         total_cost += cost

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -117,8 +117,8 @@ def hrmsd(
 def _rmsd_isomorphic_core(
     coords1: np.ndarray,
     coords2: np.ndarray,
-    atomicnums1: np.ndarray,
-    atomicnums2: np.ndarray,
+    aprops1: np.ndarray,
+    aprops2: np.ndarray,
     am1: np.ndarray,
     am2: np.ndarray,
     center: bool = False,
@@ -135,10 +135,10 @@ def _rmsd_isomorphic_core(
         Coordinate of molecule 1
     coords2: np.ndarray
         Coordinates of molecule 2
-    atomicnums1: npndarray
-        Atomic numbers for molecule 1
-    atomicnums2: npndarray
-        Atomic numbers for molecule 2
+    aprops1: np.ndarray
+        Atomic properties for molecule 1
+    aprops2: np.ndarray
+        Atomic properties for molecule 2
     am1: np.ndarray
         Adjacency matrix for molecule 1
     am2: np.ndarray
@@ -169,8 +169,8 @@ def _rmsd_isomorphic_core(
     # No cached isomorphisms
     if isomorphisms is None:
         # Convert molecules to graphs
-        G1 = graph.graph_from_adjacency_matrix(am1, atomicnums1)
-        G2 = graph.graph_from_adjacency_matrix(am2, atomicnums2)
+        G1 = graph.graph_from_adjacency_matrix(am1, aprops1)
+        G2 = graph.graph_from_adjacency_matrix(am2, aprops2)
 
         # Get all the possible graph isomorphisms
         isomorphisms = graph.match_graphs(G1, G2)
@@ -207,8 +207,8 @@ def _rmsd_isomorphic_core(
 def symmrmsd(
     coordsref: np.ndarray,
     coords: Union[np.ndarray, List[np.ndarray]],
-    atomicnumsref: np.ndarray,
-    atomicnums: np.ndarray,
+    apropsref: np.ndarray,
+    aprops: np.ndarray,
     amref: np.ndarray,
     am: np.ndarray,
     center: bool = False,
@@ -225,10 +225,10 @@ def symmrmsd(
         Coordinate of reference molecule
     coords: List[np.ndarray]
         Coordinates of other molecule
-    atomicnumsref: npndarray
-        Atomic numbers for reference
-    atomicnums: npndarray
-        Atomic numbers for other molecule
+    apropsref: np.ndarray
+        Atomic properties for reference
+    aprops: np.ndarray
+        Atomic properties for other molecule
     amref: np.ndarray
         Adjacency matrix for reference molecule
     am: np.ndarray
@@ -271,8 +271,8 @@ def symmrmsd(
             srmsd, isomorphism = _rmsd_isomorphic_core(
                 coordsref,
                 c,
-                atomicnumsref,
-                atomicnums,
+                apropsref,
+                aprops,
                 amref,
                 am,
                 center=center,
@@ -288,8 +288,8 @@ def symmrmsd(
         RMSD, isomorphism = _rmsd_isomorphic_core(
             coordsref,
             coords,
-            atomicnumsref,
-            atomicnums,
+            apropsref,
+            aprops,
             amref,
             am,
             center=center,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -97,7 +97,7 @@ def test_graph_from_adjacency_matrix_atomicnums(rawmol, mol) -> None:
     assert graph.num_edges(G) == nbonds
 
     for idx, atomicnum in enumerate(mol.atomicnums):
-        assert graph.vertex_property(G, "atomicnum", idx) == atomicnum
+        assert graph.vertex_property(G, "aprops", idx) == atomicnum
 
 
 @pytest.mark.parametrize(
@@ -110,7 +110,7 @@ def test_graph_from_adjacency_matrix_atomicnums(rawmol, mol) -> None:
 def test_match_graphs_isomorphic(G1, G2) -> None:
 
     with pytest.warns(
-        UserWarning, match="No atomic number information stored on nodes."
+        UserWarning, match="No atomic property information stored on nodes."
     ):
         isomorphisms = graph.match_graphs(G1, G2)
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -138,8 +138,8 @@ def test_match_graphs_not_isomorphic(G1, G2) -> None:
         np.array([0, 1, 2], dtype=int),
         np.array([0.1, 1.2, 2.3], dtype=float),
         np.array(["H", "H", "H"], dtype=str),
-        np.array(["He", "He", "He"], dtype=str),
         np.array(["Csp3", "Csp3", "Csp3"], dtype=str),
+        ["LongProperty", "LongPropertyProperty", "LongPropertyProperty"],
     ],
 )
 def test_build_graph_node_features(property) -> None:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -130,3 +130,20 @@ def test_match_graphs_not_isomorphic(G1, G2) -> None:
         UserWarning, match="No atomic number information stored on nodes."
     ):
         graph.match_graphs(G1, G2)
+
+
+@pytest.mark.parametrize(
+    "property",
+    [
+        np.array([0, 1, 2], dtype=int),
+        np.array([0.1, 1.2, 2.3], dtype=float),
+        np.array(["H", "H", "H"], dtype=str),
+        np.array(["He", "He", "He"], dtype=str),
+        np.array(["Csp3", "Csp3", "Csp3"], dtype=str),
+    ],
+)
+def test_build_graph_node_features(property) -> None:
+    A = np.array([[0, 1, 1], [1, 0, 0], [1, 0, 1]])
+    G = graph.graph_from_adjacency_matrix(A, property)
+
+    assert graph.num_edges(G) == 3

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -147,3 +147,16 @@ def test_build_graph_node_features(property) -> None:
     G = graph.graph_from_adjacency_matrix(A, property)
 
     assert graph.num_edges(G) == 3
+
+
+def test_build_graph_node_features_unsupported() -> None:
+    pytest.importorskip(
+        "graph_tool", reason="NetworkX supports all Python objects as node properties."
+    )
+
+    A = np.array([[0, 1, 1], [1, 0, 0], [1, 0, 1]])
+
+    property = [True, False, True]
+
+    with pytest.raises(ValueError, match="Unsupported property type:"):
+        _ = graph.graph_from_adjacency_matrix(A, property)

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -167,7 +167,7 @@ def test_graph_from_adjacency_matrix(mol: molecule.Molecule, n_bonds: int) -> No
     assert graph.num_edges(G) == n_bonds
 
     for idx, atomicnum in enumerate(mol.atomicnums):
-        assert graph.vertex_property(G, "atomicnum", idx) == atomicnum
+        assert graph.vertex_property(G, "aprops", idx) == atomicnum
 
 
 @pytest.mark.parametrize(
@@ -192,7 +192,7 @@ def test_graph_from_atomic_coordinates_perception(
         assert graph.num_edges(G) == n_bonds
 
         for idx, atomicnum in enumerate(mol.atomicnums):
-            assert graph.vertex_property(G, "atomicnum", idx) == atomicnum
+            assert graph.vertex_property(G, "aprops", idx) == atomicnum
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Fix #63. Add support for more types as node properties (including strings) with `graph-tool`. This allows to perform node matching using not only atomic numbers but also elements, atom types, ..., which is already the case for `networkx`.

TODO:
- [x] Change signature from `atomicnums` to `atomprops` (or similar)

## Checklist

- [x] Tests
- [x] Changelog
