### PR TITLE
Try to install package before deployment

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,5 +25,6 @@ jobs:
         FLIT_USERNAME: ${{ secrets.FLIT_USERNAME }}
         FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
       run: |
+        python -m pip install . --no-deps
         flit build
         flit publish

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Documentation Status](https://readthedocs.org/projects/spyrmsd/badge/?version=develop)](https://spyrmsd.readthedocs.io/en/develop/?badge=develop)
 
 [![License](https://img.shields.io/github/license/RMeli/pyrmsd?color=%2333BBFF)](https://opensource.org/licenses/MIT)
-[![PyPI](https://img.shields.io/badge/PyPI-v0.5.1%20-ff69b4)](https://pypi.org/project/spyrmsd/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.5.2%20-ff69b4)](https://pypi.org/project/spyrmsd/)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spyrmsd.svg)](https://anaconda.org/conda-forge/spyrmsd)
 
 [![J. Cheminform.](https://img.shields.io/badge/J.%20Cheminform.-10.1186%2Fs13321--020--00455--2-blue)](https://doi.org/10.1186/s13321-020-00455-2)


### PR DESCRIPTION
## Description

This PR is an attempt to fix issue #54 . The same error described in #54 was obtained locally with `flit==3.0.0`, which is a version that used to work. The `unknown+0` version was picked up at first, after fetching the new tag from the repository. However, installing `spyrmsd` with
```bash
pip install -e .
``` 
seemed to fix the issue.

This PR adds installation of `spyrmsd` before `flit build`, which hopefully will allow `flit` to pick up the correct version from the tag.