### PR TITLE
Better error message when RDKit or OpenBabel are not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Contributors:    @RMeli
 
 * LGTM badge and code annotations [PR #76 | @RMeli]
 
+### Added
+
+* Error message when `spyrmsd` is used as module but neither OpenBabel nor RDKit are installed [PR #81 | @RMeli]
+
 ------------------------------------------------------------------------------
 
 ## Version 0.5.2

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ If you find `spyrmsd` useful, please consider citing the following paper:
 
 _Note_: `spyrmsd` will install [NetworkX](https://networkx.github.io/) (multi-platform). You can install [graph-tool](https://graph-tool.skewed.de/) on macOS and Linux for higher performance.
 
+_Note_: If `spyrmsd` is used as a standalone tool, it is required to install either [RDKit](https://rdkit.org/) or [Open Babel](http://openbabel.org/). Neither is automatically installed with `pip` nor `conda`.
+
 ### PyPI
 
 ```bash

--- a/spyrmsd/__main__.py
+++ b/spyrmsd/__main__.py
@@ -4,6 +4,8 @@ Symmetry-corrected RMSD calculations in Python
 
 if __name__ == "__main__":
     import argparse as ap
+    import importlib.util
+
     import sys
 
     from spyrmsd import io
@@ -26,6 +28,14 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
+    if (
+        importlib.util.find_spec("openbabel") is None
+        and importlib.util.find_spec("rdkit") is None
+    ):
+        raise ImportError(
+            "OpenBabel or RDKit not found. Please install OpenBabel or RDKit to use sPyRMSD as a standalone tool."
+        )
 
     try:
         ref = io.loadmol(args.reference)


### PR DESCRIPTION
## Description

When using `spyrmsd` as a standalone tool, RDKit or OpenBabel need to be manually installed, since they are optional dependencies (if `spyrmsd` is used as a library).

This PR adds an error message if neither OpenBabel nor RDKit can be imported. Close #79 and close #80.

## Checklist

- [x] Documentation
- [x] Changelog
