### PR TITLE
RDKit and OpenBabel cleanup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,6 +13,3 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
-
-    # OpenBabel2
-    except ImportError:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ Contributors:    @RMeli
 
 ### Removed
 
+* Outdated information about RDKit from the documentation [PR #84 | @RMeli]
+* Support for Open Babel 2 [PR #84 | @RMeli]
 * LGTM badge and code annotations [PR #76 | @RMeli]
+
+### Added
+
+* `extras_require` to `setup.py` for RDKit and Open Babel [PR #84 | @RMeli]
 
 ------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ Additionally, one of the following packages is required to use `spyrmsd` as a st
 * [Open Babel](http://openbabel.org/)
 * [RDKit](https://rdkit.org/)
 
-_Note_: [RDKit](https://rdkit.org/) is not available on PyPI ([Why the RDKit isn't available on PyPi](https://rdkit.blogspot.com/2019/11/why-rdkit-isnt-available-on-pypi.html)). See [RDKit Installation](http://www.rdkit.org/docs/Install.html) for installation instructions.
-
 ## Usage
 
 ### Standalone Tool

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -59,13 +59,9 @@ Additionally, one of the following packages is required to use ``spyrmsd`` as a 
 * `Open Babel`_
 * RDKit_
 
-.. note::
-   RDKit_ has to be installed using ``conda`` (see `Why the RDKit isn't available on PyPi`_).
-
 .. _PyPI: https://pypi.org/project/spyrmsd/
 .. _conda-forge: https://github.com/conda-forge/spyrmsd-feedstock
 .. _RDKit: https://rdkit.org/
-.. _Why the RDKit isn't available on PyPi: https://rdkit.blogspot.com/2019/11/why-rdkit-isnt-available-on-pypi.html
 .. _Open Babel: http://openbabel.org/
 .. _graph-tool: https://graph-tool.skewed.de/
 .. _NetworkX: https://networkx.github.io/

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     include_package_data=True,
     url="https://spyrmsd.readthedocs.io",
     install_requires=["numpy", "scipy", "networkx>=2"],
-    extras_require={"bib": ["duecredit"]},
+    extras_require={"bib": ["duecredit"], "rdkit": ["rdkit"], "openbabel": ["openbabel"]},
     platforms=["Linux", "Mac OS-X", "Unix", "Windows"],
     python_requires=">=3.7",
 )

--- a/spyrmsd/optional/obabel.py
+++ b/spyrmsd/optional/obabel.py
@@ -4,14 +4,8 @@ import numpy as np
 
 from spyrmsd import molecule, utils
 
-try:
-    # 3.0
-    from openbabel import openbabel as ob
-    from openbabel import pybel
-except ImportError:
-    # 2.0
-    import openbabel as ob
-    import pybel
+from openbabel import openbabel as ob
+from openbabel import pybel
 
 
 def load(fname: str):


### PR DESCRIPTION
## Description

* Remove outdated information about RDKit from the documentation
* Add `rdkit` and `openbabel` as `extra_requires`
* Remove support Open Babel 2

Close #82, close #83.

## Checklist

- [x] Documentation
- [x] Changelog
