### PR TITLE
Add details on NotImplementedError exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 
 ------------------------------------------------------------------------------
 
+## Version X.Y.Z
+
+Date:            XX/YY/ZZZ
+Contributors:    @RMeli
+
+### Improved
+
+* Messages for `NotImplementedError` exceptions [PR #90 | @RMeli]
+
+
 ## Version 0.6.0
 
 Date:            08/09/2023

--- a/spyrmsd/optional/rdkit.py
+++ b/spyrmsd/optional/rdkit.py
@@ -64,7 +64,9 @@ def load(fname: str):
         else:
             rdmol = _load_block_gzipped(Chem.MolFromPDBBlock, fname)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"Format '{fmt}' is currently not supported with RDKit."
+        )
 
     return rdmol
 
@@ -87,7 +89,11 @@ def loadall(fname: str):
     fmt = utils.molformat(fname)
 
     if fmt == "mol2":
-        raise NotImplementedError  # See RDKit Issue #415
+        error = (
+            "Multiple molecules in MOL2 files are not supported. "
+            "See RDKit#415 (https://github.com/rdkit/rdkit/pull/415)."
+        )
+        raise NotImplementedError(error)  # See RDKit Issue #415
     elif fmt == "sdf":
         if not gzipped:
             rdmols = Chem.SDMolSupplier(fname, removeHs=False)
@@ -100,9 +106,11 @@ def loadall(fname: str):
                 mols = [rdmol for rdmol in rdmols]
     elif fmt == "pdb":
         # TODO: Implement
-        raise NotImplementedError
+        raise NotImplementedError("Multiple molecules in PDB files are not supported.")
     else:
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"Format '{fmt}' is currently not supported with RDKit."
+        )
 
     return mols
 


### PR DESCRIPTION
## Description

Some code paths lead to `NotImplementedError` exceptions. The exception are sometimes unclear an surprising to users (see #88). Close #89.

This PR adds proper error messages, to clarify the problem.  

## Checklist

- [x] Tests
- [x] Changelog
