### PR TITLE
Fix tests for pytest 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 Date:            XX/YY/ZZZZ
 Contributors:    @RMeli
 
+### Fixed
+
+* Failing tests with `pytest=8.0.0` [PR #101 | @RMeli]
+
 ### Improved
 
 * Messages for `NotImplementedError` exceptions [PR #90 | @RMeli]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ Control skipping of tests according to command line option.
 Soource:
     https://docs.pytest.org/en/latest/example/simple.html
 """
+
 import numpy as np
 import pytest
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -19,7 +19,6 @@ def systems():
     return systems
 
 
-@pytest.mark.benchmark
 @pytest.fixture(scope="module", params=systems())
 def molecules(request):
     system = request.param

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,6 +3,7 @@ import pytest
 
 from spyrmsd import constants, graph, io, molecule
 from spyrmsd.exceptions import NonIsomorphicGraphs
+from spyrmsd.graphs import _common as gc
 from tests import molecules
 
 
@@ -104,9 +105,7 @@ def test_graph_from_adjacency_matrix_atomicnums(rawmol, mol) -> None:
     ],
 )
 def test_match_graphs_isomorphic(G1, G2) -> None:
-    with pytest.warns(
-        UserWarning, match="No atomic property information stored on nodes."
-    ):
+    with pytest.warns(UserWarning, match=gc.warn_no_atomic_properties):
         isomorphisms = graph.match_graphs(G1, G2)
 
     assert len(isomorphisms) != 0
@@ -121,8 +120,8 @@ def test_match_graphs_isomorphic(G1, G2) -> None:
 )
 def test_match_graphs_not_isomorphic(G1, G2) -> None:
     with pytest.raises(
-        NonIsomorphicGraphs, match="Graphs are not isomorphic."
-    ), pytest.warns(UserWarning, match="No atomic number information stored on nodes."):
+        NonIsomorphicGraphs, match=gc.error_non_isomorphic_graphs
+    ), pytest.warns(UserWarning, match=gc.warn_no_atomic_properties):
         graph.match_graphs(G1, G2)
 
 


### PR DESCRIPTION
Fix #100. Additionally, takes care of the following `pytest` warning:

```
  /Users/romeli/mambaforge/envs/spyrmsd/lib/python3.11/site-packages/_pytest/mark/structures.py:357: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    store_mark(func, self.mark)
```