### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8
+        python -m pip install setuptools
+        python -m pip install flake8
     - name: Install  package
       run: |
         python setup.py develop --no-deps

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mypy
+        python -m pip install setuptools
+        python -m pip install mypy
     - name: Install Types
       run: |
         python -m pip install types-requests

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,8 +57,8 @@ jobs:
     - name: Install
       run: |
         python -m pip install . --no-deps
-        miniconda info
-        miniconda list
+        miniforge info
+        miniforge list
 
     - name: Test
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,11 +44,11 @@ jobs:
         df -h
         ulimit -a
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/spyrmsd-test-${{ matrix.chemlib }}-${{ matrix.graphlib }}.yaml
-        channels: conda-forge,defaults
+        miniforge-version: "latest"
         activate-environment: spyrmsd
         auto-update-conda: true
         auto-activate-base: false
@@ -57,7 +57,8 @@ jobs:
     - name: Install
       run: |
         python -m pip install . --no-deps
-        conda list
+        miniconda info
+        miniconda list
 
     - name: Test
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -59,8 +59,8 @@ jobs:
     - name: Install
       run: |
         python -m pip install . --no-deps
-        miniforge info
-        miniforge list
+        mamba info
+        mamba list
 
     - name: Test
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,14 +24,15 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         chemlib: [obabel, rdkit]
         graphlib: [nx, gt]
         exclude:
         # graph-tools does not work on Windows
         - {os: "windows-latest", graphlib: "gt"}
-        # FIXME: Keeps failing in CI for unknown reasons during miniconda setup
-        - {os: "ubuntu-latest", graphlib: "gt", chemlib: "rdkit", python-version: "3.7"}
+        include:
+        - {os: "macOS-14", graphlib: "gt", chemlib: "obabel", python-version: "3.12"}
+        - {os: "macOS-14", graphlib: "nx", chemlib: "rdkit", python-version: "3.12"}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,6 +50,8 @@ jobs:
         environment-file: devtools/conda-envs/spyrmsd-test-${{ matrix.chemlib }}-${{ matrix.graphlib }}.yaml
         miniforge-version: "latest"
         activate-environment: spyrmsd
+        miniforge-variant: Mambaforge
+        use-mamba: true
         auto-update-conda: true
         auto-activate-base: false
         show-channel-urls: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,18 @@ Contributors:    @RMeli
 
 * Failing tests with `pytest=8.0.0` [PR #101 | @RMeli]
 
+### Changed
+
+* Minimum version of Python to `3.9` (to reduce CI matrix) [PR  #102 | @RMeli]
+
 ### Improved
 
 * Messages for `NotImplementedError` exceptions [PR #90 | @RMeli]
+
+### Added
+
+* Python `3.12` to CI [PR  #102 | @RMeli]
+* macOS M1 (`macoOS-14`) to CI [PR  #102 | @RMeli]
 
 ### Removed
 

--- a/devtools/conda-envs/spyrmsd-all.yaml
+++ b/devtools/conda-envs/spyrmsd-all.yaml
@@ -7,6 +7,7 @@ dependencies:
   - python
   - pip
   - ipython
+  - setuptools
 
   # Jupyter
   - jupyterlab

--- a/devtools/conda-envs/spyrmsd-docs.yaml
+++ b/devtools/conda-envs/spyrmsd-docs.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # Base
   - python
+  - setuptools
 
   # Maths
   - numpy

--- a/devtools/conda-envs/spyrmsd-test-obabel-gt.yaml
+++ b/devtools/conda-envs/spyrmsd-test-obabel-gt.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   # Base
   - python
+  - setuptools
 
   # Maths
   - numpy

--- a/devtools/conda-envs/spyrmsd-test-obabel-nx.yaml
+++ b/devtools/conda-envs/spyrmsd-test-obabel-nx.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   # Base
   - python
+  - setuptools
 
   # Maths
   - numpy

--- a/devtools/conda-envs/spyrmsd-test-rdkit-gt.yaml
+++ b/devtools/conda-envs/spyrmsd-test-rdkit-gt.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # Base
   - python
+  - setuptools
 
   # Maths
   - numpy

--- a/devtools/conda-envs/spyrmsd-test-rdkit-nx.yaml
+++ b/devtools/conda-envs/spyrmsd-test-rdkit-nx.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # Base
   - python
+  - setuptools
 
   # Maths
   - numpy

--- a/devtools/conda-envs/spyrmsd.yaml
+++ b/devtools/conda-envs/spyrmsd.yaml
@@ -4,8 +4,9 @@ channels:
 dependencies:
   # Base
   - python
+  - setuptools
 
   # Maths
   - numpy
   - scipy
-  - graph-tool
+  - networkx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ home-page = "https://spyrmsd.readthedocs.io"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 requires = ["numpy", "scipy", "networkx>=2"]

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setup(
         "openbabel": ["openbabel"],
     },
     platforms=["Linux", "Mac OS-X", "Unix", "Windows"],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
## Description

Update CI:

* Remove Python `3.7` and `3.8` to reduce the size of the CI matrix
* Add `macOS-14` (M1) to CI matrix, only for Python `3.12`

## Checklist

- [x] Tests
- [x] Changelog
