### PR TITLE
Backend selection

### DIFF
--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -1,43 +1,30 @@
-try:
-    from spyrmsd.graphs.gt import (
-        cycle,
-        graph_from_adjacency_matrix,
-        lattice,
-        match_graphs,
-        num_edges,
-        num_vertices,
-        vertex_property,
-    )
-
-except ImportError:
-    try:
-        from spyrmsd.graphs.nx import (
-            cycle,
-            graph_from_adjacency_matrix,
-            lattice,
-            match_graphs,
-            num_edges,
-            num_vertices,
-            vertex_property,
-        )
-    except ImportError:
-        raise ImportError("graph_tool or NetworkX libraries not found.")
-
-__all__ = [
-    "graph_from_adjacency_matrix",
-    "match_graphs",
-    "vertex_property",
-    "num_vertices",
-    "num_edges",
-    "lattice",
-    "cycle",
-    "adjacency_matrix_from_atomic_coordinates",
-]
-
 import numpy as np
+import sys
 
 from spyrmsd import constants
 
+## Checking and initializing the available backends
+graph_backends = []
+
+try:
+    import spyrmsd.graphs.gt
+    graph_backends.append("graph_tool")
+
+except ImportError:
+    print("Graph Tool backend not found")
+    
+try:
+   import spyrmsd.graphs.nx
+   graph_backends.append("networkx")
+   
+except ImportError:
+    print("NetworkX backend not found")
+
+if len(graph_backends) == 0:
+    sys.exit("No valid graph backends were found, please make sure atleast one of the supported backends is installed correctly")
+
+def get_backends():
+    return graph_backends
 
 def adjacency_matrix_from_atomic_coordinates(
     aprops: np.ndarray, coordinates: np.ndarray

--- a/spyrmsd/graphs/nx.py
+++ b/spyrmsd/graphs/nx.py
@@ -190,3 +190,4 @@ def cycle(n):
         Cycle graph
     """
     return nx.cycle_graph(n)
+

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -162,7 +162,7 @@ def _rmsd_isomorphic_core(
     available_backends = graph.get_backends()
     
     # Check the backend
-    if backend.lower() in ["graphtool", "graph-tool", "graph_tool", "gt"]:
+    if backend.lower() in ["graphtool", "graph-tool", "graph_tool", "graph tool", "gt"]:
         if "graph_tool" in available_backends:
             import spyrmsd.graphs.gt as graph_backend        
         else:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,10 +4,14 @@ import pytest
 from spyrmsd import constants, graph, io, molecule
 from spyrmsd.exceptions import NonIsomorphicGraphs
 from spyrmsd.graphs import _common as gc
+from spyrmsd.graphs import gt, nx
 from tests import molecules
 
-
-def test_adjacency_matrix_from_atomic_coordinates_distance() -> None:
+@pytest.mark.parametrize(
+    "graph_backend",
+    [gt, nx],
+)
+def test_adjacency_matrix_from_atomic_coordinates_distance(graph_backend) -> None:
     # Lithium hydride (LiH)
     # H and Li have very different covalent radii
     atomicnums = np.array([1, 3])
@@ -22,24 +26,27 @@ def test_adjacency_matrix_from_atomic_coordinates_distance() -> None:
     )
 
     A = graph.adjacency_matrix_from_atomic_coordinates(atomicnums, coordinates)
-    G = graph.graph_from_adjacency_matrix(A)
+    G = graph_backend.graph_from_adjacency_matrix(A)
 
-    assert graph.num_edges(G) == 1
+    assert graph_backend.num_edges(G) == 1
 
-
+@pytest.mark.parametrize(
+    "graph_backend",
+    [gt, nx],
+)
 @pytest.mark.parametrize(
     "mol, n_bonds",
     [(molecules.benzene, 12), (molecules.ethanol, 8), (molecules.dialanine, 22)],
 )
 def test_adjacency_matrix_from_atomic_coordinates(
-    mol: molecule.Molecule, n_bonds: int
+    mol: molecule.Molecule, n_bonds: int, graph_backend
 ) -> None:
     A = graph.adjacency_matrix_from_atomic_coordinates(mol.atomicnums, mol.coordinates)
 
-    G = graph.graph_from_adjacency_matrix(A)
+    G = graph_backend.graph_from_adjacency_matrix(A)
 
-    assert graph.num_vertices(G) == len(mol)
-    assert graph.num_edges(G) == n_bonds
+    assert graph_backend.num_vertices(G) == len(mol)
+    assert graph_backend.num_edges(G) == n_bonds
 
 
 @pytest.mark.parametrize("mol", molecules.allobmolecules)
@@ -56,9 +63,9 @@ def test_adjacency_matrix_from_mol(mol) -> None:
     for i, j in io.bonds(mol):
         assert A[i, j] == 1
 
-
+@pytest.mark.parametrize("graph_backend",[gt, nx])
 @pytest.mark.parametrize("mol", molecules.allobmolecules)
-def test_graph_from_adjacency_matrix(mol) -> None:
+def test_graph_from_adjacency_matrix(mol, graph_backend) -> None:
     natoms = io.numatoms(mol)
     nbonds = io.numbonds(mol)
 
@@ -68,16 +75,19 @@ def test_graph_from_adjacency_matrix(mol) -> None:
     assert np.all(A == A.T)
     assert np.sum(A) == nbonds * 2
 
-    G = graph.graph_from_adjacency_matrix(A)
+    G = graph_backend.graph_from_adjacency_matrix(A)
 
-    assert graph.num_vertices(G) == natoms
-    assert graph.num_edges(G) == nbonds
+    assert graph_backend.num_vertices(G) == natoms
+    assert graph_backend.num_edges(G) == nbonds
 
-
+@pytest.mark.parametrize(
+    "graph_backend, graph_backend_name",
+    [(gt,"gt"), (nx, "nx")],
+)
 @pytest.mark.parametrize(
     "rawmol, mol", zip(molecules.allobmolecules, molecules.allmolecules)
 )
-def test_graph_from_adjacency_matrix_atomicnums(rawmol, mol) -> None:
+def test_graph_from_adjacency_matrix_atomicnums(rawmol, mol, graph_backend, graph_backend_name) -> None:
     natoms = io.numatoms(rawmol)
     nbonds = io.numbonds(rawmol)
 
@@ -88,43 +98,49 @@ def test_graph_from_adjacency_matrix_atomicnums(rawmol, mol) -> None:
     assert np.all(mol.adjacency_matrix == A)
     assert np.sum(mol.adjacency_matrix) == nbonds * 2
 
-    G = mol.to_graph()
+    G = mol.to_graph(backend=graph_backend_name)
 
-    assert graph.num_vertices(G) == natoms
-    assert graph.num_edges(G) == nbonds
+    assert graph_backend.num_vertices(G) == natoms
+    assert graph_backend.num_edges(G) == nbonds
 
     for idx, atomicnum in enumerate(mol.atomicnums):
-        assert graph.vertex_property(G, "aprops", idx) == atomicnum
+        assert graph_backend.vertex_property(G, "aprops", idx) == atomicnum
 
 
 @pytest.mark.parametrize(
-    "G1, G2",
+    "G1, G2, graph_backend",
     [
-        *[(graph.lattice(n, n), graph.lattice(n, n)) for n in range(2, 5)],
-        *[(graph.cycle(n), graph.cycle(n)) for n in range(2, 5)],
+        *[(gt.lattice(n, n), gt.lattice(n, n), gt) for n in range(2, 5)],
+        *[(nx.lattice(n, n), nx.lattice(n, n), nx) for n in range(2, 5)],
+        *[(gt.cycle(n), gt.cycle(n), gt) for n in range(2, 5)],
+        *[(nx.cycle(n), nx.cycle(n), nx) for n in range(2, 5)],
     ],
 )
-def test_match_graphs_isomorphic(G1, G2) -> None:
+def test_match_graphs_isomorphic(G1, G2, graph_backend) -> None:
     with pytest.warns(UserWarning, match=gc.warn_no_atomic_properties):
-        isomorphisms = graph.match_graphs(G1, G2)
+        isomorphisms = graph_backend.match_graphs(G1, G2)
 
     assert len(isomorphisms) != 0
 
+@pytest.mark.parametrize(
+    "G1, G2, graph_backend",
+    [
+        *[(gt.lattice(n, n), gt.lattice(n + 1, n), gt) for n in range(2, 5)],
+        *[(nx.lattice(n, n), nx.lattice(n + 1, n), nx) for n in range(2, 5)],
+        *[(gt.cycle(n), gt.cycle(n + 1), gt) for n in range(1, 5)],
+        *[(nx.cycle(n), nx.cycle(n + 1), nx) for n in range(1, 5)],
+    ]
+)
+def test_match_graphs_not_isomorphic(G1, G2, graph_backend) -> None:
+    with pytest.raises(
+        graph_backend.NonIsomorphicGraphs, match=gc.error_non_isomorphic_graphs
+    ), pytest.warns(UserWarning, match=gc.warn_no_atomic_properties):
+        graph_backend.match_graphs(G1, G2)
 
 @pytest.mark.parametrize(
-    "G1, G2",
-    [
-        *[(graph.lattice(n, n), graph.lattice(n + 1, n)) for n in range(2, 5)],
-        *[(graph.cycle(n), graph.cycle(n + 1)) for n in range(1, 5)],
-    ],
+    "graph_backend",
+    [gt, nx],
 )
-def test_match_graphs_not_isomorphic(G1, G2) -> None:
-    with pytest.raises(
-        NonIsomorphicGraphs, match=gc.error_non_isomorphic_graphs
-    ), pytest.warns(UserWarning, match=gc.warn_no_atomic_properties):
-        graph.match_graphs(G1, G2)
-
-
 @pytest.mark.parametrize(
     "property",
     [
@@ -134,22 +150,21 @@ def test_match_graphs_not_isomorphic(G1, G2) -> None:
         np.array(["Csp3", "Csp3", "Csp3"], dtype=str),
         ["LongProperty", "LongPropertyProperty", "LongPropertyProperty"],
     ],
+    ids=lambda prop: f"{type(prop).__name__}"
 )
-def test_build_graph_node_features(property) -> None:
+def test_build_graph_node_features(graph_backend, property) -> None:
     A = np.array([[0, 1, 1], [1, 0, 0], [1, 0, 1]])
-    G = graph.graph_from_adjacency_matrix(A, property)
+    G = graph_backend.graph_from_adjacency_matrix(A, property)
 
-    assert graph.num_edges(G) == 3
+    assert graph_backend.num_edges(G) == 3
 
 
 def test_build_graph_node_features_unsupported() -> None:
-    pytest.importorskip(
-        "graph_tool", reason="NetworkX supports all Python objects as node properties."
-    )
 
     A = np.array([[0, 1, 1], [1, 0, 0], [1, 0, 1]])
 
     property = [True, False, True]
 
     with pytest.raises(ValueError, match="Unsupported property type:"):
-        _ = graph.graph_from_adjacency_matrix(A, property)
+        #Only test graph_tool since NetworkX supports all Python objects as node properties.
+        _ = gt.graph_from_adjacency_matrix(A, property)

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -143,34 +143,39 @@ def test_molecule_strip(mol: molecule.Molecule, n_atoms: int, stripped: int) -> 
 
     assert len(m) == n_atoms - stripped
 
-@pytest.mark.parametrize(
-    "graph_backend, graph_backend_name",
-    [(gt,"gt"), (nx, "nx")],
-)
+@pytest.fixture(params=[(gt, "gt"), (nx, "nx")], ids=["gt", "nx"])
+def graph_backend(request):
+    return request.param[0], request.param[1]
+
+
 @pytest.mark.parametrize(
     "mol, n_bonds",
-    [(molecules.benzene, 12), (molecules.ethanol, 8), (molecules.dialanine, 22)],
+    [
+        (molecules.benzene, 12),
+        (molecules.ethanol, 8),
+        (molecules.dialanine, 22)
+    ]
 )
-def test_graph_from_adjacency_matrix(mol: molecule.Molecule, n_bonds: int, graph_backend, graph_backend_name) -> None:
-    G = mol.to_graph(backend=graph_backend_name)
-    print(type(G))
-    assert graph_backend.num_vertices(G) == len(mol)
-    assert graph_backend.num_edges(G) == n_bonds
+def test_graph_from_adjacency_matrix(mol: molecule.Molecule, n_bonds: int, graph_backend) -> None:
+    backend, backend_name = graph_backend
+    G = mol.to_graph(backend=backend_name)
+    assert backend.num_vertices(G) == len(mol)
+    assert backend.num_edges(G) == n_bonds
 
     for idx, atomicnum in enumerate(mol.atomicnums):
-        assert graph_backend.vertex_property(G, "aprops", idx) == atomicnum
+        assert backend.vertex_property(G, "aprops", idx) == atomicnum
+
 
 @pytest.mark.parametrize(
-    "graph_backend, graph_backend_name",
-    [(gt,"gt"), (nx, "nx")],
-)
-@pytest.mark.parametrize(
     "mol, n_bonds",
-    [(molecules.benzene, 12), (molecules.ethanol, 8), (molecules.dialanine, 22)],
+    [
+        (molecules.benzene, 12),
+        (molecules.ethanol, 8),
+        (molecules.dialanine, 22)
+    ]
 )
-def test_graph_from_atomic_coordinates_perception(
-    mol: molecule.Molecule, n_bonds: int, graph_backend, graph_backend_name
-) -> None:
+def test_graph_from_atomic_coordinates_perception(mol: molecule.Molecule, n_bonds: int, graph_backend) -> None:
+    backend, backend_name = graph_backend
     m = copy.deepcopy(mol)
 
     delattr(m, "adjacency_matrix")
@@ -178,13 +183,13 @@ def test_graph_from_atomic_coordinates_perception(
 
     with pytest.warns(UserWarning):
         # Uses automatic bond perception
-        G = m.to_graph(backend=graph_backend_name)
+        G = m.to_graph(backend=backend_name)
         
-        assert graph_backend.num_vertices(G) == len(m)
-        assert graph_backend.num_edges(G) == n_bonds
+        assert backend.num_vertices(G) == len(m)
+        assert backend.num_edges(G) == n_bonds
 
         for idx, atomicnum in enumerate(mol.atomicnums):
-            assert graph_backend.vertex_property(G, "aprops", idx) == atomicnum
+            assert backend.vertex_property(G, "aprops", idx) == atomicnum
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This is my attempt to adress issue #68 
For the functions that work with _rmsd_isomorphic_core, there is now a specific option to select the backend: "graph_tool" or "networkx". There is also the "default" option, which will mimic the original behavior: first it tries Graph Tool followed by (trying to) fall back on NetworkX. If you specifically select a backend that isn't available, an error will be raised. I also had to update/modify many of the tests to implement this new behavior, but now everything is passing again.

## Changelog
- Added the (optional) backend selection for _rmsd_isomorphic_core (and symrmsd and rmsdwrapper)
- Added (optional) backend selection for molecule.to_graph()
- Removed most of the (imported) methods from graph.py and instead dynamically use the correct ones directly from gt.py or nx.py accordingly
- Updated tests to accommodate the new behavior. I only modified molecule_test.py, for the to_graph() function, and the graph_test.py, to explicitly test everything with both NetworkX and graph-tool as a backend.

## Documentation
The recognized arguments for the backend feature are:

- Graph Tool: "graph_tool", "graphtool", "graph tool", "graph-tool" and "gt"
- NetworkX: "networkx" and "nx"

They are all case insensitive, so things like "GraphTool" or "NetworkX" will also work without problem

## Checklist

- [x] Tests (passes after modifying it for the new behavior)
- [x] Documentation
- [x] Changelog
