### PR TITLE
Add functionality to select backend

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,7 +30,7 @@ jobs:
         exclude:
         # graph-tools does not work on Windows
         - {os: "windows-latest", graphlib: "gt"}
-        - {graphlib: "all", chemlib: "openbabel"}
+        - {graphlib: "all", chemlib: "obabel"}
         include:
         - {os: "macOS-14", graphlib: "gt", chemlib: "obabel", python-version: "3.12"}
         - {os: "macOS-14", graphlib: "nx", chemlib: "rdkit", python-version: "3.12"}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,10 +26,11 @@ jobs:
         os: [macOS-latest, ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         chemlib: [obabel, rdkit]
-        graphlib: [nx, gt]
+        graphlib: [nx, gt, all]
         exclude:
         # graph-tools does not work on Windows
         - {os: "windows-latest", graphlib: "gt"}
+        - {graphlib: "all", chemlib: "openbabel"}
         include:
         - {os: "macOS-14", graphlib: "gt", chemlib: "obabel", python-version: "3.12"}
         - {os: "macOS-14", graphlib: "nx", chemlib: "rdkit", python-version: "3.12"}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,7 @@ jobs:
         exclude:
         # graph-tools does not work on Windows
         - {os: "windows-latest", graphlib: "gt"}
+        - {os: "windows-latest", graphlib: "all"}
         - {graphlib: "all", chemlib: "obabel"}
         include:
         - {os: "macOS-14", graphlib: "gt", chemlib: "obabel", python-version: "3.12"}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     rev: 5.12.0
     hooks:
     -   id: isort
+        args: ["--profile", "black"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.5.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 ## Version X.Y.Z
 
 Date:            XX/YY/ZZZZ
-Contributors:    @RMeli, @takluyver
+Contributors:    @RMeli, @takluyver, @Jnelen
+
+### Added
+
+* Functionality to manually select the backend [PR  #107 | @Jnelen, @RMeli]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Contributors:    @RMeli, @takluyver, @Jnelen
 
 ### Added
 
-* Functionality to manually select the backend [PR  #107 | @Jnelen, @RMeli]
+* Functionality to manually select the backend [PR  #107 | @Jnelen]
+
+### Changed
+
+* Molecular graphs are now cached per backend using a dictionary [PR  #107 | @Jnelen]
 
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,9 @@ authors:
 - family-names: "Meli"
   given-names: "Rocco"
   orcid: "https://orcid.org/0000-0002-2845-3410"
+- family-names: "Nelen"
+  given-names: "Jochem"
+  orcid: "https://orcid.org/0000-0002-9970-4950"
 title: "spyrmsd"
 version: 0.6.0
 doi: 10.5281/zenodo.3631876

--- a/devtools/conda-envs/spyrmsd-test-rdkit-all.yaml
+++ b/devtools/conda-envs/spyrmsd-test-rdkit-all.yaml
@@ -1,0 +1,28 @@
+name: spyrmsd
+channels:
+  - conda-forge
+  - rdkit
+dependencies:
+  # Base
+  - python
+  - setuptools
+
+  # Maths
+  - numpy
+  - scipy
+  - graph-tool
+  - networkx>=2
+
+  # Chemistry
+  - rdkit
+
+  # Testing
+  - pytest
+  - pytest-cov
+  - pytest-benchmark
+
+  # Dev
+  - mypy
+  - flake8
+  - black
+  - codecov

--- a/spyrmsd/__init__.py
+++ b/spyrmsd/__init__.py
@@ -3,6 +3,7 @@ Python RMSD tool with symmetry correction.
 """
 
 from .due import Doi, due
+
 # Make the backend related functions available from base spyrmsd
 # Add noqa to avoid flake8 error
 from .graph import _available_backends as available_backends  # noqa: F401

--- a/spyrmsd/__init__.py
+++ b/spyrmsd/__init__.py
@@ -3,6 +3,11 @@ Python RMSD tool with symmetry correction.
 """
 
 from .due import Doi, due
+# Make the backend related functions available from base spyrmsd
+# Add noqa to avoid flake8 error
+from .graph import _available_backends as available_backends  # noqa: F401
+from .graph import _get_backend as get_backend  # noqa: F401
+from .graph import _set_backend as set_backend  # noqa: F401
 
 __version__ = "0.7.0-dev"
 

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -75,17 +75,13 @@ def _validate_backend(backend):
     return standardized_backend
 
 
-# def _get_available_backends():
-#    return _available_backends
-
-
 def _set_backend(backend):
     global _current_backend
     backend = _validate_backend(backend)
 
     ## Check if we actually need to switch backends
     if backend == _current_backend:
-        warnings.warn(f"The backend is already {backend}")
+        warnings.warn(f"The backend is already {backend}.")
         return
 
     global cycle, graph_from_adjacency_matrix, lattice, match_graphs, num_edges, num_vertices, vertex_property

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -1,42 +1,97 @@
-try:
-    from spyrmsd.graphs.gt import (
-        cycle,
-        graph_from_adjacency_matrix,
-        lattice,
-        match_graphs,
-        num_edges,
-        num_vertices,
-        vertex_property,
-    )
-
-except ImportError:
-    try:
-        from spyrmsd.graphs.nx import (
-            cycle,
-            graph_from_adjacency_matrix,
-            lattice,
-            match_graphs,
-            num_edges,
-            num_vertices,
-            vertex_property,
-        )
-    except ImportError:
-        raise ImportError("graph_tool or NetworkX libraries not found.")
-
-__all__ = [
-    "graph_from_adjacency_matrix",
-    "match_graphs",
-    "vertex_property",
-    "num_vertices",
-    "num_edges",
-    "lattice",
-    "cycle",
-    "adjacency_matrix_from_atomic_coordinates",
-]
+from spyrmsd import constants
 
 import numpy as np
+import os
 
-from spyrmsd import constants
+available_backends = []
+
+try:
+    from spyrmsd.graphs.gt import (
+        cycle as gt_cycle,
+        graph_from_adjacency_matrix as gt_graph_from_adjacency_matrix,
+        lattice as gt_lattice,
+        match_graphs as gt_match_graphs,
+        num_edges as gt_num_edges,
+        num_vertices as gt_num_vertices,
+        vertex_property as gt_vertex_property,
+    )
+    available_backends.append("graph-tool")
+except ImportError:
+    pass
+    
+try:
+   from spyrmsd.graphs.nx import (
+        cycle as nx_cycle,
+        graph_from_adjacency_matrix as nx_graph_from_adjacency_matrix,
+        lattice as nx_lattice,
+        match_graphs as nx_match_graphs,
+        num_edges as nx_num_edges,
+        num_vertices as nx_num_vertices,
+        vertex_property as nx_vertex_property,
+    )
+   available_backends.append("networkx")
+except ImportError:
+   pass
+        
+def get_available_backends():
+    return available_backends 
+
+def set_backend(backend):
+
+    ## Get the current backend
+    current_backend = str(os.environ.get("SPYRMSD_BACKEND"))
+  
+    ## Check if the backend is valid
+    if backend.lower() in ["graph_tool", "graphtool", "graph-tool", "graph tool", "gt"]:
+        backend = "graph-tool"
+    elif backend.lower() in ["networkx", "nx"]:
+        backend = "networkx"
+    else:
+        raise ValueError("This backend is not recognized or supported")
+
+    ## Check if we the backend is installed
+    if not backend in available_backends:
+        raise ImportError(f"The {backend} backend doesn't seem to be installed")
+
+    ## Check if we actually need to switch backends
+    if backend == current_backend:
+        print(f"The backend is already {backend}")
+        return
+        
+    global cycle, graph_from_adjacency_matrix, lattice, match_graphs, num_edges, num_vertices, vertex_property
+    
+    if backend == "graph-tool":      
+        
+        cycle = gt_cycle
+        graph_from_adjacency_matrix = gt_graph_from_adjacency_matrix
+        lattice = gt_lattice
+        match_graphs = gt_match_graphs
+        num_edges = gt_num_edges
+        num_vertices = gt_num_vertices
+        vertex_property = gt_vertex_property
+              
+    elif backend == "networkx":
+              
+        cycle = nx_cycle
+        graph_from_adjacency_matrix = nx_graph_from_adjacency_matrix
+        lattice = nx_lattice
+        match_graphs = nx_match_graphs
+        num_edges = nx_num_edges
+        num_vertices = nx_num_vertices
+        vertex_property = nx_vertex_property      
+
+    ## Update the environment variable
+    os.environ["SPYRMSD_BACKEND"] = backend
+
+if len(available_backends) == 0:
+    raise ImportError("No valid backends found. Please ensure atleast Graph-Tool or NetworkX are properly installed")
+else:
+    if os.environ.get("SPYRMSD_BACKEND") is None:
+        ## Set the backend to the first available (preferred) backend         
+        set_backend(backend=available_backends[0])
+    
+def get_backend():
+    return os.environ.get("SPYRMSD_BACKEND")
 
 
 def adjacency_matrix_from_atomic_coordinates(

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -1,7 +1,8 @@
-from spyrmsd import constants
+import warnings
 
 import numpy as np
-import warnings
+
+from spyrmsd import constants
 
 _available_backends = []
 _current_backend = None
@@ -11,64 +12,67 @@ _graph_tool_aliases = ["graph_tool", "graphtool", "graph-tool", "graph tool", "g
 _networkx_aliases = ["networkx", "nx"]
 
 ## Construct the alias dictionary
-_alias_backendDict = {}
+_alias_to_backend = {}
 for alias in _graph_tool_aliases:
-    _alias_backendDict[alias.lower()] = "graph-tool"
+    _alias_to_backend[alias.lower()] = "graph-tool"
 for alias in _networkx_aliases:
-    _alias_backendDict[alias.lower()] = "networkx"
+    _alias_to_backend[alias.lower()] = "networkx"
 
 try:
+    from spyrmsd.graphs.gt import cycle as gt_cycle
     from spyrmsd.graphs.gt import (
-        cycle as gt_cycle,
         graph_from_adjacency_matrix as gt_graph_from_adjacency_matrix,
-        lattice as gt_lattice,
-        match_graphs as gt_match_graphs,
-        num_edges as gt_num_edges,
-        num_vertices as gt_num_vertices,
-        vertex_property as gt_vertex_property,
     )
+    from spyrmsd.graphs.gt import lattice as gt_lattice
+    from spyrmsd.graphs.gt import match_graphs as gt_match_graphs
+    from spyrmsd.graphs.gt import num_edges as gt_num_edges
+    from spyrmsd.graphs.gt import num_vertices as gt_num_vertices
+    from spyrmsd.graphs.gt import vertex_property as gt_vertex_property
+
     _available_backends.append("graph-tool")
 except ImportError:
     warnings.warn("The graph-tool backend does not seem to be installed.", stacklevel=2)
-    
+
 try:
-   from spyrmsd.graphs.nx import (
-        cycle as nx_cycle,
+    from spyrmsd.graphs.nx import cycle as nx_cycle
+    from spyrmsd.graphs.nx import (
         graph_from_adjacency_matrix as nx_graph_from_adjacency_matrix,
-        lattice as nx_lattice,
-        match_graphs as nx_match_graphs,
-        num_edges as nx_num_edges,
-        num_vertices as nx_num_vertices,
-        vertex_property as nx_vertex_property,
     )
-   _available_backends.append("networkx")
+    from spyrmsd.graphs.nx import lattice as nx_lattice
+    from spyrmsd.graphs.nx import match_graphs as nx_match_graphs
+    from spyrmsd.graphs.nx import num_edges as nx_num_edges
+    from spyrmsd.graphs.nx import num_vertices as nx_num_vertices
+    from spyrmsd.graphs.nx import vertex_property as nx_vertex_property
+
+    _available_backends.append("networkx")
 except ImportError:
-   warnings.warn("The networkx backend does not seem to be installed.", stacklevel=2)
+    warnings.warn("The networkx backend does not seem to be installed.", stacklevel=2)
 
 
 def _validate_backend(backend):
-    standardized_backend = _alias_backendDict.get(backend.lower())
+    standardized_backend = _alias_to_backend.get(backend.lower())
     if standardized_backend is None:
         raise ValueError("This backend is not recognized or supported")
     if standardized_backend not in _available_backends:
         raise ImportError(f"The {backend} backend doesn't seem to be installed")
     return standardized_backend
 
+
 def available_backends():
-    return _available_backends 
+    return _available_backends
+
 
 def set_backend(backend):
-    ## Check if the backend is valid
     backend = _validate_backend(backend)
 
     ## Check if we actually need to switch backends
     if backend == _current_backend:
         warnings.warn(f"The backend is already {backend}", stacklevel=2)
         return _current_backend
-        
+
     global cycle, graph_from_adjacency_matrix, lattice, match_graphs, num_edges, num_vertices, vertex_property
-    
-    if backend == "graph-tool":      
+
+    if backend == "graph-tool":
         cycle = gt_cycle
         graph_from_adjacency_matrix = gt_graph_from_adjacency_matrix
         lattice = gt_lattice
@@ -76,7 +80,7 @@ def set_backend(backend):
         num_edges = gt_num_edges
         num_vertices = gt_num_vertices
         vertex_property = gt_vertex_property
-              
+
     elif backend == "networkx":
         cycle = nx_cycle
         graph_from_adjacency_matrix = nx_graph_from_adjacency_matrix
@@ -84,17 +88,32 @@ def set_backend(backend):
         match_graphs = nx_match_graphs
         num_edges = nx_num_edges
         num_vertices = nx_num_vertices
-        vertex_property = nx_vertex_property      
+        vertex_property = nx_vertex_property
 
     return backend
 
+
+__all__ = [
+    "graph_from_adjacency_matrix",
+    "match_graphs",
+    "vertex_property",
+    "num_vertices",
+    "num_edges",
+    "lattice",
+    "cycle",
+    "adjacency_matrix_from_atomic_coordinates",
+]
+
 if len(_available_backends) == 0:
-    raise ImportError("No valid backends found. Please ensure that either graph-tool or NetworkX are installed.")
+    raise ImportError(
+        "No valid backends found. Please ensure that either graph-tool or NetworkX are installed."
+    )
 else:
     if _current_backend is None:
-        ## Set the backend to the first available (preferred) backend         
+        ## Set the backend to the first available (preferred) backend
         _current_backend = set_backend(backend=_available_backends[0])
-    
+
+
 def get_backend():
     return _current_backend
 

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -48,7 +48,7 @@ try:
 
     _available_backends.append("graph-tool")
 except ImportError:
-    warnings.warn("The graph-tool backend does not seem to be installed.", stacklevel=2)
+    warnings.warn("The graph-tool backend does not seem to be installed.")
 
 try:
     from spyrmsd.graphs.nx import cycle as nx_cycle
@@ -63,7 +63,7 @@ try:
 
     _available_backends.append("networkx")
 except ImportError:
-    warnings.warn("The networkx backend does not seem to be installed.", stacklevel=2)
+    warnings.warn("The networkx backend does not seem to be installed.")
 
 
 def _validate_backend(backend):
@@ -75,17 +75,17 @@ def _validate_backend(backend):
     return standardized_backend
 
 
-def available_backends():
-    return _available_backends
+# def _get_available_backends():
+#    return _available_backends
 
 
-def set_backend(backend):
+def _set_backend(backend):
     global _current_backend
     backend = _validate_backend(backend)
 
     ## Check if we actually need to switch backends
     if backend == _current_backend:
-        warnings.warn(f"The backend is already {backend}", stacklevel=2)
+        warnings.warn(f"The backend is already {backend}")
         return
 
     global cycle, graph_from_adjacency_matrix, lattice, match_graphs, num_edges, num_vertices, vertex_property
@@ -118,10 +118,10 @@ if len(_available_backends) == 0:
 else:
     if _current_backend is None:
         ## Set the backend to the first available (preferred) backend
-        set_backend(backend=_available_backends[0])
+        _set_backend(backend=_available_backends[0])
 
 
-def get_backend():
+def _get_backend():
     return _current_backend
 
 

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -111,17 +111,6 @@ def set_backend(backend):
     _current_backend = backend
 
 
-__all__ = [
-    "graph_from_adjacency_matrix",
-    "match_graphs",
-    "vertex_property",
-    "num_vertices",
-    "num_edges",
-    "lattice",
-    "cycle",
-    "adjacency_matrix_from_atomic_coordinates",
-]
-
 if len(_available_backends) == 0:
     raise ImportError(
         "No valid backends found. Please ensure that either graph-tool or NetworkX are installed."

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -129,7 +129,7 @@ if len(_available_backends) == 0:
 else:
     if _current_backend is None:
         ## Set the backend to the first available (preferred) backend
-        _current_backend = set_backend(backend=_available_backends[0])
+        set_backend(backend=_available_backends[0])
 
 
 def get_backend():

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -2,6 +2,7 @@ from spyrmsd import constants
 
 import numpy as np
 import os
+import warnings
 
 _available_backends = []
 
@@ -15,7 +16,7 @@ try:
         num_vertices as gt_num_vertices,
         vertex_property as gt_vertex_property,
     )
-    available_backends.append("graph-tool")
+    _available_backends.append("graph-tool")
 except ImportError:
     pass
     
@@ -29,7 +30,7 @@ try:
         num_vertices as nx_num_vertices,
         vertex_property as nx_vertex_property,
     )
-   available_backends.append("networkx")
+   _available_backends.append("networkx")
 except ImportError:
    pass
         
@@ -50,12 +51,12 @@ def set_backend(backend):
         raise ValueError("This backend is not recognized or supported")
 
     ## Check if we the backend is installed
-    if not backend in available_backends:
+    if not backend in _available_backends:
         raise ImportError(f"The {backend} backend doesn't seem to be installed")
 
     ## Check if we actually need to switch backends
     if backend == current_backend:
-        print(f"The backend is already {backend}")
+        warnings.warn(f"The backend is already {backend}", stacklevel=2)
         return
         
     global cycle, graph_from_adjacency_matrix, lattice, match_graphs, num_edges, num_vertices, vertex_property
@@ -88,7 +89,7 @@ if len(_available_backends) == 0:
 else:
     if os.environ.get("SPYRMSD_BACKEND") is None:
         ## Set the backend to the first available (preferred) backend         
-        set_backend(backend=available_backends[0])
+        set_backend(backend=_available_backends[0])
     
 def get_backend():
     return os.environ.get("SPYRMSD_BACKEND")

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -18,6 +18,23 @@ for alias in _graph_tool_aliases:
 for alias in _networkx_aliases:
     _alias_to_backend[alias.lower()] = "networkx"
 
+
+def _dummy(*args, **kwargs):
+    """
+    Dummy function for backend not set.
+    """
+    raise NotImplementedError("No backend is set.")
+
+
+## Assigning the properties/methods associated with a backend to a temporary dummy function
+cycle = _dummy
+graph_from_adjacency_matrix = _dummy
+lattice = _dummy
+match_graphs = _dummy
+num_edges = _dummy
+num_vertices = _dummy
+vertex_property = _dummy
+
 try:
     from spyrmsd.graphs.gt import cycle as gt_cycle
     from spyrmsd.graphs.gt import (

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -52,7 +52,7 @@ except ImportError:
 def _validate_backend(backend):
     standardized_backend = _alias_to_backend.get(backend.lower())
     if standardized_backend is None:
-        raise ValueError("This backend is not recognized or supported")
+        raise ValueError(f"The {backend} backend is not recognized or supported")
     if standardized_backend not in _available_backends:
         raise ImportError(f"The {backend} backend doesn't seem to be installed")
     return standardized_backend

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -63,12 +63,13 @@ def available_backends():
 
 
 def set_backend(backend):
+    global _current_backend
     backend = _validate_backend(backend)
 
     ## Check if we actually need to switch backends
     if backend == _current_backend:
         warnings.warn(f"The backend is already {backend}", stacklevel=2)
-        return _current_backend
+        return
 
     global cycle, graph_from_adjacency_matrix, lattice, match_graphs, num_edges, num_vertices, vertex_property
 
@@ -90,7 +91,7 @@ def set_backend(backend):
         num_vertices = nx_num_vertices
         vertex_property = nx_vertex_property
 
-    return backend
+    _current_backend = backend
 
 
 __all__ = [

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -3,7 +3,7 @@ from spyrmsd import constants
 import numpy as np
 import os
 
-available_backends = []
+_available_backends = []
 
 try:
     from spyrmsd.graphs.gt import (
@@ -33,8 +33,8 @@ try:
 except ImportError:
    pass
         
-def get_available_backends():
-    return available_backends 
+def available_backends():
+    return _available_backends 
 
 def set_backend(backend):
 
@@ -83,8 +83,8 @@ def set_backend(backend):
     ## Update the environment variable
     os.environ["SPYRMSD_BACKEND"] = backend
 
-if len(available_backends) == 0:
-    raise ImportError("No valid backends found. Please ensure atleast Graph-Tool or NetworkX are properly installed")
+if len(_available_backends) == 0:
+    raise ImportError("No valid backends found. Please ensure that either graph-tool or NetworkX are installed.")
 else:
     if os.environ.get("SPYRMSD_BACKEND") is None:
         ## Set the backend to the first available (preferred) backend         

--- a/spyrmsd/molecule.py
+++ b/spyrmsd/molecule.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 
@@ -50,7 +50,7 @@ class Molecule:
             self.adjacency_matrix: np.ndarray = np.asarray(adjacency_matrix, dtype=int)
 
         # Molecular graph
-        self.G = None
+        self.G: Dict[str, object] = {}
 
         self.masses: Optional[List[float]] = None
 
@@ -182,7 +182,7 @@ class Molecule:
                 self.adjacency_matrix = self.adjacency_matrix[np.ix_(idx, idx)]
 
             # Reset molecular graph when stripping
-            self.G = None
+            self.G = {}
 
             self.stripped = True
 
@@ -200,11 +200,13 @@ class Molecule:
         If the molecule does not have an associated adjacency matrix, a simple
         bond perception is used.
 
-        The molecular graph is cached.
+        The molecular graph is cached per backend.
         """
-        if self.G is None:
+        _current_backend = graph._current_backend
+
+        if _current_backend not in self.G.keys():
             try:
-                self.G = graph.graph_from_adjacency_matrix(
+                self.G[_current_backend] = graph.graph_from_adjacency_matrix(
                     self.adjacency_matrix, self.atomicnums
                 )
             except AttributeError:
@@ -218,11 +220,11 @@ class Molecule:
                     self.atomicnums, self.coordinates
                 )
 
-                self.G = graph.graph_from_adjacency_matrix(
+                self.G[_current_backend] = graph.graph_from_adjacency_matrix(
                     self.adjacency_matrix, self.atomicnums
                 )
 
-        return self.G
+        return self.G[_current_backend]
 
     def __len__(self) -> int:
         """

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -161,10 +161,10 @@ def test_build_graph_node_features_unsupported() -> None:
     reason="Not all of the required backends are installed",
 )
 def test_set_backend() -> None:
-    A = np.array([[0, 1, 1], [1, 0, 0], [1, 0, 1]])
-
     import graph_tool as gt
     import networkx as nx
+    
+    A = np.array([[0, 1, 1], [1, 0, 0], [1, 0, 1]])
 
     spyrmsd.set_backend("networkx")
     assert spyrmsd.get_backend() == "networkx"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -163,7 +163,7 @@ def test_build_graph_node_features_unsupported() -> None:
 def test_set_backend() -> None:
     import graph_tool as gt
     import networkx as nx
-    
+
     A = np.array([[0, 1, 1], [1, 0, 0], [1, 0, 1]])
 
     spyrmsd.set_backend("networkx")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import spyrmsd
 from spyrmsd import constants, graph, io, molecule
 from spyrmsd.exceptions import NonIsomorphicGraphs
 from spyrmsd.graphs import _common as gc
@@ -153,3 +154,29 @@ def test_build_graph_node_features_unsupported() -> None:
 
     with pytest.raises(ValueError, match="Unsupported property type:"):
         _ = graph.graph_from_adjacency_matrix(A, property)
+
+
+@pytest.mark.skipif(
+    len(spyrmsd.available_backends) < 2,
+    reason="Not all of the required backends are installed",
+)
+def test_set_backend() -> None:
+    A = np.array([[0, 1, 1], [1, 0, 0], [1, 0, 1]])
+
+    import graph_tool as gt
+    import networkx as nx
+
+    spyrmsd.set_backend("networkx")
+    assert spyrmsd.get_backend() == "networkx"
+
+    Gnx = graph.graph_from_adjacency_matrix(A)
+    assert isinstance(Gnx, nx.Graph)
+
+    spyrmsd.set_backend("graph-tool")
+    assert spyrmsd.get_backend() == "graph-tool"
+
+    Ggt = graph.graph_from_adjacency_matrix(A)
+    assert isinstance(Ggt, gt.Graph)
+
+    with pytest.raises(ValueError, match="backend is not recognized or supported"):
+        spyrmsd.set_backend("unknown")

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -167,7 +167,7 @@ def test_graph_from_atomic_coordinates_perception(
     m = copy.deepcopy(mol)
 
     delattr(m, "adjacency_matrix")
-    m.G = None
+    m.G = {}
 
     with pytest.warns(UserWarning):
         # Uses automatic bond perception


### PR DESCRIPTION
Hi,

Here is my second try at implementing the backend selection feature. I've been quite busy, so that's why it took a bit longer than I wanted to put this pull request. Either way, below is a short summary:
I only modified graph.py, and I tried to change as little as possible.
I use environment variables to check and update backend. I also added a function to check all available backends, and to see the current backend. (That last one maybe is a bit redundant and could be removed). 
Everything seems to work fine, except there is one edge-case/"bug" with the to_graph() functionality of a molecule: if you use this before and after switching to another backend for the same molecule, it will still return the graph of the old backend because of the cache. I would propose to make use of a dictionary structure, where the (standardized) names of the backends serve as keys and the values the graphs. I could implement this quite easily, but ofcourse this would require some tweaks to molecule.py. That's why I waited with implementing this in order to first hear your opinion. Maybe there's a better way? 
Also, I didn't add any tests yes, since I'd like your feedback/opinion first! After that i'll gladly spend some more time to polish everything!

---

Close #68
