### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,16 +1,21 @@
-# .readthedocs.yml
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "mambaforge-22.9"
+
 sphinx:
   builder: html
   configuration: docs/source/conf.py
+  configuration: docs/conf.py
 
 formats:
-  - epub
   - pdf
+  - epub
 
 conda:
   environment: devtools/conda-envs/spyrmsd-docs.yaml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,6 @@ build:
 sphinx:
   builder: html
   configuration: docs/source/conf.py
-  configuration: docs/conf.py
 
 formats:
   - pdf


### PR DESCRIPTION
Documentation builds were failing with

```
Error

Config validation error in `build.os`. Value `build` not found.
```

This PR updates the `.readthedocs.yml` file.