### PR TITLE
Use IDs in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 
 ------------------------------------------------------------------------------
 
+## Version X.Y.Z
+
+Date:            XX/YY/ZZZZ
+Contributors:    @RMeli
+
+### Improved
+
+* Test IDs [PR | @RMeli]
+
 ## Version 0.7.0
 
 Date:            05/04/2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Contributors:    @RMeli
 
 ### Improved
 
-* Test IDs [PR | @RMeli]
+* Test IDs [PR #117 | @RMeli]
 
 ## Version 0.7.0
 
@@ -19,7 +19,7 @@ Contributors:    @RMeli, @takluyver, @Jnelen
 
 ### Added
 
-* Support for `rustworkx` graph library [PR 111 | @RMeli]
+* Support for `rustworkx` graph library [PR #111 | @RMeli]
 * Functionality to manually select the backend from CLI [PR #108 | @RMeli]
 * Functionality to manually select the backend [PR  #107 | @Jnelen]
 * Python `3.12` to CI [PR  #102 | @RMeli]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Contributors:    @RMeli, @takluyver, @Jnelen
 ### Changed
 
 * Molecular graphs cache to cache by backend [PR  #107 | @Jnelen]
-* Python build system to use flit_core directly [PR #103 | @takluyver]
+* Python build system to use `flit_core` directly [PR #103 | @takluyver]
 * Minimum version of Python to `3.9` (to reduce CI matrix) [PR  #102 | @RMeli]
 
 ### Fixed

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -40,7 +40,7 @@ def molecules(request):
 
 
 @pytest.mark.benchmark
-@pytest.mark.parametrize("cache", [True, False])
+@pytest.mark.parametrize("cache", [True, False], ids=["cache", "no_cache"])
 def test_benchmark_symmrmsd(cache, molecules, benchmark):
     ref, mols, system = molecules
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -31,6 +31,7 @@ def test_adjacency_matrix_from_atomic_coordinates_distance() -> None:
 @pytest.mark.parametrize(
     "mol, n_bonds",
     [(molecules.benzene, 12), (molecules.ethanol, 8), (molecules.dialanine, 22)],
+    ids=["benzene", "ethanol", "dialanine"],
 )
 def test_adjacency_matrix_from_atomic_coordinates(
     mol: molecule.Molecule, n_bonds: int

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,6 +11,7 @@ molpath = os.path.join(fdir, "data/molecules/")
 @pytest.mark.parametrize(
     "molfile, natoms, nbonds",
     [("benzene.sdf", 12, 12), ("ethanol.sdf", 9, 8), ("dialanine.sdf", 23, 22)],
+    ids=["benzene", "ethanol", "dialanine"],
 )
 def test_load_sdf(molfile, natoms: int, nbonds: int) -> None:
     m = io.load(os.path.join(molpath, molfile))
@@ -22,6 +23,7 @@ def test_load_sdf(molfile, natoms: int, nbonds: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms, nbonds",
     [("1cbr_ligand.mol2", 49, 49)],
+    ids=["1cbr_ligand"],
 )
 def test_load_mol2(molfile, natoms: int, nbonds: int) -> None:
     m = io.load(os.path.join(molpath, molfile))
@@ -33,6 +35,7 @@ def test_load_mol2(molfile, natoms: int, nbonds: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms, nbonds",
     [("trp0.pdb", 217, 224), ("trp1.pdb", 217, 224), ("trp2.pdb", 217, 224)],
+    ids=["trp0", "trp1", "trp2"],
 )
 def test_load_pdb(molfile, natoms: int, nbonds: int) -> None:
     m = io.load(os.path.join(molpath, molfile))
@@ -44,6 +47,7 @@ def test_load_pdb(molfile, natoms: int, nbonds: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms, nbonds",
     [("1cbr_docking.sdf", 22, 22)],
+    ids=["1cbr_docking"],
 )
 def test_loadall_sdf(molfile, natoms: int, nbonds: int) -> None:
     ms = io.loadall(os.path.join(molpath, molfile))
@@ -58,6 +62,7 @@ def test_loadall_sdf(molfile, natoms: int, nbonds: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms, nbonds",
     [("1cbr_docking.mol2", 22, 22)],
+    ids=["1cbr_docking"],
 )
 def test_loadall_mol2(molfile, natoms: int, nbonds: int) -> None:
     try:
@@ -75,6 +80,7 @@ def test_loadall_mol2(molfile, natoms: int, nbonds: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms, nbonds",
     [("1cbr_docking.pdb", 22, 22)],
+    ids=["1cbr_docking"],
 )
 def test_loadall_pdb(molfile, natoms: int, nbonds: int) -> None:
     try:
@@ -110,6 +116,7 @@ def test_loadall_pdb_single_model() -> None:
 @pytest.mark.parametrize(
     "molfile, natoms",
     [("benzene.sdf", 12), ("ethanol.sdf", 9), ("dialanine.sdf", 23)],
+    ids=["benzene", "ethanol", "dialanine"],
 )
 def test_loadmol_sdf(molfile, natoms: int) -> None:
     m = io.loadmol(os.path.join(molpath, molfile))
@@ -120,6 +127,7 @@ def test_loadmol_sdf(molfile, natoms: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms",
     [("benzene.mol2", 12), ("1cbr_ligand.mol2", 49)],
+    ids=["benzene", "1cbr_ligand"],
 )
 def test_loadmol_mol2(molfile, natoms: int) -> None:
     m = io.loadmol(os.path.join(molpath, molfile))
@@ -130,6 +138,7 @@ def test_loadmol_mol2(molfile, natoms: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms",
     [("1cbr_docking.sdf", 22)],
+    ids=["1cbr_docking"],
 )
 def test_loadallmols_sdf(molfile, natoms: int) -> None:
     ms = io.loadallmols(os.path.join(molpath, molfile))
@@ -143,6 +152,7 @@ def test_loadallmols_sdf(molfile, natoms: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms",
     [("benzene.sdf.gz", 12), ("benzene.mol2.gz", 12), ("1a99_ligand.pdb.gz", 20)],
+    ids=["benzene", "benzene_mol2", "1a99_ligand"],
 )
 def test_loadmol_gz(molfile, natoms: int) -> None:
     m = io.loadmol(os.path.join(molpath, molfile))
@@ -153,6 +163,7 @@ def test_loadmol_gz(molfile, natoms: int) -> None:
 @pytest.mark.parametrize(
     "molfile, natoms",
     [("1cbr_docking.sdf.gz", 22)],
+    ids=["1cbr_docking"],
 )
 def test_loadallmols_sdf_gz(molfile, natoms: int) -> None:
     ms = io.loadallmols(os.path.join(molpath, molfile))

--- a/tests/test_large.py
+++ b/tests/test_large.py
@@ -8,7 +8,9 @@ import requests
 from spyrmsd import io, qcp, rmsd
 
 
-@pytest.fixture(autouse=True, params=[True, False])
+@pytest.fixture(
+    autouse=True, params=[True, False], ids=["lamnda_max_fast", "lambda_max_fallback"]
+)
 def lambda_max_failure(monkeypatch, request):
     """
     Monkey patch fixture for :code:`lambda_max` function to simulate convergence
@@ -95,7 +97,7 @@ def test_dowload(download, path):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("minimize", [True, False])
+@pytest.mark.parametrize("minimize", [True, False], ids=["minimize", "no_minimize"])
 def test_rmsd(idx, download, path, minimize):
     id = download[idx]
 

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -19,6 +19,7 @@ from tests import molecules
         (molecules.ethanol, [(1, 6), (6, 2), (8, 1)]),
         (molecules.dialanine, [(1, 12), (6, 6), (7, 2), (8, 3)]),
     ],
+    ids=["benzene", "ethanol", "dialanine"],
 )
 def test_load(mol: molecule.Molecule, atoms: List[Tuple[int, int]]) -> None:
     n = sum([n_atoms for _, n_atoms in atoms])
@@ -133,6 +134,7 @@ def test_molecule_center_of_mass_HF() -> None:
         (molecules.ethanol, 9, 6),
         (molecules.dialanine, 23, 12),
     ],
+    ids=["benzene", "ethanol", "dialanine"],
 )
 def test_molecule_strip(mol: molecule.Molecule, n_atoms: int, stripped: int) -> None:
     m = copy.deepcopy(mol)
@@ -147,6 +149,7 @@ def test_molecule_strip(mol: molecule.Molecule, n_atoms: int, stripped: int) -> 
 @pytest.mark.parametrize(
     "mol, n_bonds",
     [(molecules.benzene, 12), (molecules.ethanol, 8), (molecules.dialanine, 22)],
+    ids=["benzene", "ethanol", "dialanine"],
 )
 def test_graph_from_adjacency_matrix(mol: molecule.Molecule, n_bonds: int) -> None:
     G = mol.to_graph()
@@ -161,6 +164,7 @@ def test_graph_from_adjacency_matrix(mol: molecule.Molecule, n_bonds: int) -> No
 @pytest.mark.parametrize(
     "mol, n_bonds",
     [(molecules.benzene, 12), (molecules.ethanol, 8), (molecules.dialanine, 22)],
+    ids=["benzene", "ethanol", "dialanine"],
 )
 def test_graph_from_atomic_coordinates_perception(
     mol: molecule.Molecule, n_bonds: int
@@ -184,6 +188,7 @@ def test_graph_from_atomic_coordinates_perception(
 @pytest.mark.parametrize(
     "adjacency",
     [True, False],
+    ids=["adjacency", "no_adjacency"],
 )
 def test_from_obmol(adjacency):
     pytest.importorskip("openbabel")
@@ -213,6 +218,7 @@ def test_from_obmol(adjacency):
 @pytest.mark.parametrize(
     "adjacency",
     [True, False],
+    ids=["adjacency", "no_adjacency"],
 )
 def test_from_rdmol(adjacency):
     pytest.importorskip("rdkit")
@@ -245,7 +251,9 @@ def test_from_rdmol(adjacency):
     reason="Not all of the required backends are installed",
 )
 @pytest.mark.parametrize(
-    "mol", [(molecules.benzene), (molecules.ethanol), (molecules.dialanine)]
+    "mol",
+    [(molecules.benzene), (molecules.ethanol), (molecules.dialanine)],
+    ids=["benzene", "ethanol", "dialanine"],
 )
 def test_molecule_graph_cache(mol) -> None:
     import graph_tool as gt

--- a/tests/test_qcp.py
+++ b/tests/test_qcp.py
@@ -55,6 +55,7 @@ def test_K_mtx(mol: molecule.Molecule) -> None:
         ((-1, -1, -5, 0, 4), -1),  # f(x) = x^4 - 5 * x^2 + 4; x_0 = -1/2
         ((-3, -3, -5, 0, 4), -2),  # f(x) = x^4 - 5 * x^2 + 4; x_0 = -3
     ],
+    ids=["f1", "f2", "f3", "f4", "f5", "f6"],
 )
 def test_lambda_max(
     input: Tuple[float, float, float, float, float], result: float

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -8,7 +8,9 @@ from spyrmsd import molecule, qcp, rmsd
 from tests import molecules
 
 
-@pytest.fixture(autouse=True, params=[True, False])
+@pytest.fixture(
+    autouse=True, params=[True, False], ids=["lambda_max_fast", "lambda_max_fallback"]
+)
 def lambda_max_failure(monkeypatch, request):
     """
     Monkey patch fixture for :code:`lambda_max` function to simulate convergence
@@ -37,7 +39,9 @@ def lambda_max_failure(monkeypatch, request):
         monkeypatch.setattr(qcp, "lambda_max", lambda_max_failure)
 
 
-@pytest.mark.parametrize("t, RMSD", [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)])
+@pytest.mark.parametrize(
+    "t, RMSD", [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)], ids=["t0", "t1", "t2"]
+)
 def test_rmsd_benzene(t: float, RMSD: float) -> None:
     mol1 = copy.deepcopy(molecules.benzene)
     mol2 = copy.deepcopy(molecules.benzene)
@@ -52,7 +56,9 @@ def test_rmsd_benzene(t: float, RMSD: float) -> None:
 # Results obtained with PyTraj
 #   pytraj.analysis.rmsd.rmsd(i, ref=j, nofit=True)
 @pytest.mark.parametrize(
-    "i, j, result", [(1, 2, 2.60065218), (1, 3, 9.94411523), (2, 3, 9.4091711)]
+    "i, j, result",
+    [(1, 2, 2.60065218), (1, 3, 9.94411523), (2, 3, 9.4091711)],
+    ids=["1-2", "1-3", "2-3"],
 )
 def test_rmsd_2viz(i: int, j: int, result: float) -> None:
     moli = copy.deepcopy(molecules.docking_2viz[i])
@@ -66,7 +72,9 @@ def test_rmsd_2viz(i: int, j: int, result: float) -> None:
 # Results obtained with PyTraj
 #   pytraj.analysis.rmsd.rmsd(i, mask="!@H=", ref=j, ref_mask="!@H=", nofit=True)
 @pytest.mark.parametrize(
-    "i, j, result", [(1, 2, 2.65327362), (1, 3, 10.11099065), (2, 3, 9.57099612)]
+    "i, j, result",
+    [(1, 2, 2.65327362), (1, 3, 10.11099065), (2, 3, 9.57099612)],
+    ids=["1-2", "1-3", "2-3"],
 )
 def test_rmsd_2viz_stripped(i: int, j: int, result: float) -> None:
     moli = copy.deepcopy(molecules.docking_2viz[i])
@@ -139,7 +147,9 @@ def test_rmsd_minimize(mol: molecule.Molecule) -> None:
 # Results obtained with PyTraj
 #   pytraj.analysis.rmsd.rmsd(i, ref=j)
 @pytest.mark.parametrize(
-    "i, j, result", [(1, 2, 1.95277757), (1, 3, 3.11801105), (2, 3, 2.98609758)]
+    "i, j, result",
+    [(1, 2, 1.95277757), (1, 3, 3.11801105), (2, 3, 2.98609758)],
+    ids=["1-2", "1-3", "2-3"],
 )
 def test_rmsd_qcp_2viz(i: int, j: int, result: float) -> None:
     moli = copy.deepcopy(molecules.docking_2viz[i])
@@ -157,7 +167,9 @@ def test_rmsd_qcp_2viz(i: int, j: int, result: float) -> None:
 # Results obtained with PyTraj
 #   pytraj.analysis.rmsd.rmsd(i, "!@H=", ref=j, ref_mask="!@H=")
 @pytest.mark.parametrize(
-    "i, j, result", [(1, 2, 1.98171656), (1, 3, 3.01799306), (2, 3, 2.82917355)]
+    "i, j, result",
+    [(1, 2, 1.98171656), (1, 3, 3.01799306), (2, 3, 2.82917355)],
+    ids=["1-2", "1-3", "2-3"],
 )
 def test_rmsd_qcp_2viz_stripped(i: int, j: int, result: float) -> None:
     moli = copy.deepcopy(molecules.docking_2viz[i])
@@ -194,6 +206,7 @@ def test_rmsd_qcp_2viz_stripped(i: int, j: int, result: float) -> None:
         (4, 9.772939589989000, 2.1234944939308220),
         (5, 8.901837608843241, 2.4894805175766606),
     ],
+    ids=["1", "2", "3", "4", "5"],
 )
 def test_rmsd_qcp_protein(i: int, rmsd_dummy: float, rmsd_min: float):
     mol0 = copy.deepcopy(molecules.trp[0])
@@ -213,7 +226,9 @@ def test_rmsd_qcp_protein(i: int, rmsd_dummy: float, rmsd_min: float):
 
 
 @pytest.mark.parametrize(
-    "angle, tol", [(60, 1e-4), (120, 1e-4), (180, 1e-4), (240, 1e-4), (300, 1e-4)]
+    "angle, tol",
+    [(60, 1e-4), (120, 1e-4), (180, 1e-4), (240, 1e-4), (300, 1e-4)],
+    ids=["60", "120", "180", "240", "300"],
 )
 def test_rmsd_hungarian_benzene_rotated(angle: float, tol: float) -> None:
     mol1 = copy.deepcopy(molecules.benzene)
@@ -239,9 +254,13 @@ def test_rmsd_hungarian_benzene_rotated(angle: float, tol: float) -> None:
     ) == pytest.approx(0, abs=tol)
 
 
-@pytest.mark.parametrize("d", [-0.5, 0.0, 0.5, 1.0, 1.5])
 @pytest.mark.parametrize(
-    "angle, tol", [(60, 1e-4), (120, 1e-4), (180, 1e-4), (240, 1e-4), (300, 1e-4)]
+    "d", [-0.5, 0.0, 0.5, 1.0, 1.5], ids=["t1", "t2", "t3", "t4", "t5"]
+)
+@pytest.mark.parametrize(
+    "angle, tol",
+    [(60, 1e-4), (120, 1e-4), (180, 1e-4), (240, 1e-4), (300, 1e-4)],
+    ids=["60", "120", "180", "240", "300"],
 )
 def test_rmsd_hungarian_benzene_shifted_rotated(
     d: float, angle: float, tol: float
@@ -443,6 +462,28 @@ def test_symmrmsd_atomicnums_matching_pyridine_stripped() -> None:
         (9, 0.965387, True),
         (10, 1.37842, True),
     ],
+    ids=[
+        "1-no_minimize",
+        "2-no_minimize",
+        "3-no_minimize",
+        "4-no_minimize",
+        "5-no_minimize",
+        "6-no_minimize",
+        "7-no_minimize",
+        "8-no_minimize",
+        "9-no_minimize",
+        "10-no_minimize",
+        "1-minimize",
+        "2-minimize",
+        "3-minimize",
+        "4-minimize",
+        "5-minimize",
+        "6-minimize",
+        "7-minimize",
+        "8-minimize",
+        "9-minimize",
+        "10-minimize",
+    ],
 )
 def test_rmsd_symmrmsd(index: int, RMSD: float, minimize: bool) -> None:
     molc = copy.deepcopy(molecules.docking_1cbr[0])
@@ -508,6 +549,7 @@ def test_rmsd_symmrmsd_disconnected_node() -> None:
             ],
         ),
     ],
+    ids=["no_minimize", "minimize"],
 )
 def test_multi_spyrmsd(minimize: bool, referenceRMSDs: List[float]) -> None:
     molc = copy.deepcopy(molecules.docking_1cbr[0])
@@ -567,6 +609,7 @@ def test_multi_spyrmsd(minimize: bool, referenceRMSDs: List[float]) -> None:
             ],
         ),
     ],
+    ids=["no_minimize", "minimize"],
 )
 def test_symmrmsd_cache(minimize: bool, referenceRMSDs: List[float]) -> None:
     molc = copy.deepcopy(molecules.docking_1cbr[0])
@@ -709,7 +752,9 @@ def test_issue_35_2():
 
 
 @pytest.mark.parametrize(
-    "i, j, result", [(1, 2, 1.95277757), (1, 3, 3.11801105), (2, 3, 2.98609758)]
+    "i, j, result",
+    [(1, 2, 1.95277757), (1, 3, 3.11801105), (2, 3, 2.98609758)],
+    ids=["1-2", "1-3", "2-3"],
 )
 def test_rmsd_atol(i: int, j: int, result: float):
     """
@@ -744,7 +789,9 @@ def test_rmsd_atol(i: int, j: int, result: float):
 
 
 # Results obtained with OpenBabel
-@pytest.mark.parametrize("i, reference", [(1, 0.476858), (2, 1.68089), (3, 1.50267)])
+@pytest.mark.parametrize(
+    "i, reference", [(1, 0.476858), (2, 1.68089), (3, 1.50267)], ids=["1", "2", "3"]
+)
 def test_symmrmsd_atol(i: bool, reference: float) -> None:
     moli = copy.deepcopy(molecules.docking_1cbr[0])
     molj = copy.deepcopy(molecules.docking_1cbr[i])
@@ -852,6 +899,7 @@ def test_symmrmsd_atol_multi() -> None:
             ],
         ),
     ],
+    ids=["no_minimize", "minimize"],
 )
 def test_rmsdwrapper_nosymm_protein(minimize: bool, referenceRMSDs: List[float]):
     mol0 = copy.deepcopy(molecules.trp[0])
@@ -898,6 +946,7 @@ def test_rmsdwrapper_nosymm_protein(minimize: bool, referenceRMSDs: List[float])
             ],
         ),
     ],
+    ids=["minimize", "no_minimize"],
 )
 def test_rmsdwrapper_isomorphic(minimize: bool, referenceRMSDs: List[float]) -> None:
     molref = copy.deepcopy(molecules.docking_1cbr[0])
@@ -913,6 +962,7 @@ def test_rmsdwrapper_isomorphic(minimize: bool, referenceRMSDs: List[float]) -> 
     # Reference results obtained with OpenBabel
     "minimize, referenceRMSD",
     [(True, 0.476858), (False, 0.592256)],
+    ids=["minimize", "no_minimize"],
 )
 def test_rmsdwrapper_single_molecule(minimize: bool, referenceRMSD: float) -> None:
     molref = copy.deepcopy(molecules.docking_1cbr[0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@ def test_molformat(extin: str, extout: str) -> None:
 @pytest.mark.parametrize(
     "deg, rad",
     [(0, 0), (90, np.pi / 2), (180, np.pi), (270, 3 * np.pi / 2), (360, 2 * np.pi)],
+    ids=["0", "90", "180", "270", "360"],
 )
 def test_deg_to_rad(deg: float, rad: float) -> None:
     assert utils.deg_to_rad(deg) == pytest.approx(rad)


### PR DESCRIPTION
## Description

Some test names are not very descriptive, and can create confusion (see  https://github.com/RMeli/spyrmsd/pull/113#issuecomment-2002642711). This PR introduces IDs in tests in order to have better and more explicit test names (when running with `--verbose`, as in CI).

Close #115.

## Checklist

- [x] Changelog
