### PR TITLE
Update GitHub actions and pre-commit configuration

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
           python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
           python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,7 +38,7 @@ jobs:
           - {os: "macOS-14", graphlib: "all", chemlib: "rdkit", python-version: "3.12"}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Info
       shell: bash
@@ -70,7 +70,7 @@ jobs:
         pytest -v --benchmark --cov=spyrmsd --cov-report=xml --color=yes tests/
 
     - name: CodeCov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
         flags: unittests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ exclude: |
             )$
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
     - id: check-json
     - id: check-merge-conflict
@@ -14,20 +14,20 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.4.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     -   id: isort
         args: ["--profile", "black"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.9.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Contributors:    @RMeli
 
 ### Changed
 
+* `pre-commit` versions [PR #120 | @RMeli] 
 * Versions of several GitHub Actions [PR #120 | @RMeli] 
 * Location of backend tests to standalone file [PR #118 | @RMeli]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ Contributors:    @RMeli
 
 ### Changed
 
-* `pre-commit` versions [PR #120 | @RMeli] 
-* Versions of several GitHub Actions [PR #120 | @RMeli] 
+* `pre-commit` versions [PR #120 | @RMeli]
+* Versions of several GitHub Actions [PR #120 | @RMeli]
 * Location of backend tests to standalone file [PR #118 | @RMeli]
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Contributors:    @RMeli
 
 ### Changed
 
+* Versions of several GitHub Actions [PR #120 | @RMeli] 
 * Location of backend tests to standalone file [PR #118 | @RMeli]
 
 ### Removed


### PR DESCRIPTION
## Description

Update GitHub actions. Avoids the following warnings:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, codecov/codecov-action@v3.

## Checklist

- [ ] Changelog
