### PR TITLE
Make rustworkx the default backend in pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Contributors:    @RMeli
 
 ### Changed
 
+* the default backend for `pip` installations to `rustworkx` [PR#122 | @RMeli]
 * `pre-commit` versions [PR #120 | @RMeli]
 * Versions of several GitHub Actions [PR #120 | @RMeli]
 * Location of backend tests to standalone file [PR #118 | @RMeli]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you find `spyrmsd` useful, please consider citing the following paper:
 `spyrmsd` is available on [PyPI](https://pypi.org/project/spyrmsd/) and [conda-forge](https://github.com/conda-forge/spyrmsd-feedstock) and can be easily installed from source. See [Dependencies](###Dependencies) for a description of all the dependencies.
 
 > [!NOTE]
-> `spyrmsd` will install [NetworkX](https://networkx.github.io/) (multi-platform). You can install the other backends for higher performance.
+> `spyrmsd` will install [rustworkx] (multi-platform) when using `pip` or `conda`. You can install other backends manually.
 
 > [!WARNING]
 > If `spyrmsd` is used as a standalone tool, it is required to install either [RDKit](https://rdkit.org/) or [Open Babel](http://openbabel.org/). Neither is automatically installed with `pip` nor `conda`.
@@ -76,11 +76,11 @@ The following packages are required to use `spyrmsd` as a module:
 
 One of the following graph libraries is required:
 * [graph-tool]
-* [NetworkX]
 * [rustworkx]
+* [NetworkX]
 
 > [!NOTE]
-> `spyrmsd` uses the following priority when multiple graph libraries are present: [graph-tool], [NetworkX], [rustworkx]. *This order might change. Use `set_backend` to ensure you are always using the same backend, if needed.* However, in order to support cross-platform installation [NetworkX](https://networkx.github.io/) is installed by default, and the other graph library need to be installed manually.
+> `spyrmsd` uses the following priority when multiple graph libraries are present: [graph-tool], [rustworkx], [NetworkX]. *This order might change. Use `set_backend` to ensure you are always using the same backend, if needed.*
 
 #### Standalone Tool
 
@@ -178,10 +178,10 @@ To ensure code quality and consistency the following tools are used during devel
 
 * [black](https://black.readthedocs.io/en/stable/)
 * [Flake 8](http://flake8.pycqa.org/en/latest/) (CI)
-* [isort]()
+* [isort](https://pycqa.github.io/isort/)
 * [mypy](http://mypy-lang.org/) (CI)
 
-Pre-commit `git` hooks can be installed with [pre-commit](https://pre-commit.com/).
+Pre-commit `git` hooks can be installed with [pre-commit].
 
 ## Copyright
 
@@ -198,3 +198,4 @@ Project based on the [Computational Molecular Science Python Cookiecutter](https
 [rustworkx]: https://www.rustworkx.org
 [NetworkX]: https://networkx.github.io/
 [graph-tool]: https://graph-tool.skewed.de/
+[pre-commit]: https://pre-commit.com/

--- a/devtools/conda-envs/spyrmsd-all.yaml
+++ b/devtools/conda-envs/spyrmsd-all.yaml
@@ -16,8 +16,9 @@ dependencies:
   - numpy
   - pandas
   - scipy
-  - networkx>=2
   - graph-tool
+  - rustworkx
+  - networkx>=2
   - scikit-learn
 
   # Chemistry

--- a/devtools/conda-envs/spyrmsd-docs.yaml
+++ b/devtools/conda-envs/spyrmsd-docs.yaml
@@ -12,6 +12,7 @@ dependencies:
   - scipy
   - networkx>=2
   - graph-tool
+  - rustworkx
 
   # Chemistry
   - openbabel

--- a/devtools/conda-envs/spyrmsd.yaml
+++ b/devtools/conda-envs/spyrmsd.yaml
@@ -9,4 +9,4 @@ dependencies:
   # Maths
   - numpy
   - scipy
-  - networkx
+  - rustworkx

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -44,12 +44,12 @@ Module
 
 The following packages are required to use ``spyrmsd`` as a module:
 
-* graph-tool_ or NetworkX_
+* graph-tool_, rustworkx_, or NetworkX_
 * numpy_
 * scipy_
 
 .. note::
-   ``spyrmsd`` uses graph-tool_ by default but will  fall back  to NetworkX_ if the former is not installed (e.g. on Windows).
+   ``spyrmsd`` uses graph-tool_ by default but will fall back to either rustworkx_ or NetworkX_ if the former is not installed (e.g. on Windows).
 
 Standalone Tool
 ~~~~~~~~~~~~~~~
@@ -67,3 +67,4 @@ Additionally, one of the following packages is required to use ``spyrmsd`` as a 
 .. _NetworkX: https://networkx.github.io/
 .. _numpy: https://numpy.org/
 .. _scipy: https://www.scipy.org/
+.. _rustworkx: https://www.rustworkx.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,4 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",]
 requires-python = ">=3.9"
-requires = ["numpy", "scipy", "networkx>=2"]
+requires = ["numpy", "scipy", "rustworkx"]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     url="https://spyrmsd.readthedocs.io",
-    install_requires=["numpy", "scipy", "networkx>=2"],
+    install_requires=["numpy", "scipy", "rustworkx"],
     extras_require={
         "bib": ["duecredit"],
         "rdkit": ["rdkit"],

--- a/spyrmsd/__main__.py
+++ b/spyrmsd/__main__.py
@@ -66,8 +66,8 @@ if __name__ == "__main__":
             warnings.simplefilter("ignore")
             spyrmsd.set_backend(args.graph_backend)
 
-            if args.verbose:
-                print(f"Graph library: {spyrmsd.get_backend()}")
+    if args.verbose:
+        print(f"Graph library: {spyrmsd.get_backend()}")
 
     # Loop over molecules within fil
     RMSDlist = rmsdwrapper(

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -5,7 +5,10 @@ import numpy as np
 
 from spyrmsd import constants
 
-_supported_backends = ("graph_tool", "networkx", "rustworkx")
+# The first backend found from this list is set as default
+# TODO: Need to determine if graph_tool or rustworkx is better
+# NetworkX is slow, therefore it is the last resort
+_supported_backends = ("graph_tool", "rustworkx", "networkx")
 
 _available_backends = []
 _current_backend = None


### PR DESCRIPTION
## Description

Close https://github.com/RMeli/spyrmsd/issues/121.

* Make `rustworkx` the default backend when installing with `pip`
  * The same change will be reflected in the condo-forge recipe
* Change the order of precedence for the default backend: `networkx` is the very last resort

## Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog
