### PR TITLE
Remove RDKit pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,11 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/PyCQA/isort
@@ -27,7 +27,7 @@ repos:
     -   id: isort
         args: ["--profile", "black"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.11.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/devtools/conda-envs/spyrmsd-test-rdkit-nogt.yaml
+++ b/devtools/conda-envs/spyrmsd-test-rdkit-nogt.yaml
@@ -18,9 +18,7 @@ dependencies:
   - pebble
 
   # Chemistry
-  # TODO: Remove pin when issue is fixed upstream
-  # INFO: See https://github.com/RMeli/spyrmsd/pull/134
-  - rdkit<=2024.03.4
+  - rdkit
 
   # Testing
   - pytest


### PR DESCRIPTION
Remove RDKit pin introduced in #134. Closes #135.

https://github.com/conda-forge/rdkit-feedstock/pull/169