### PR TITLE
Use miniforge instead of mambaforge

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,7 +53,6 @@ jobs:
         environment-file: devtools/conda-envs/spyrmsd-test-${{ matrix.chemlib }}-${{ matrix.graphlib }}.yaml
         miniforge-version: "latest"
         activate-environment: spyrmsd
-        miniforge-variant: "latest"
         use-mamba: true
         auto-update-conda: true
         auto-activate-base: false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,7 +53,7 @@ jobs:
         environment-file: devtools/conda-envs/spyrmsd-test-${{ matrix.chemlib }}-${{ matrix.graphlib }}.yaml
         miniforge-version: "latest"
         activate-environment: spyrmsd
-        miniforge-variant: Mambaforge
+        miniforge-variant: "latest"
         use-mamba: true
         auto-update-conda: true
         auto-activate-base: false


### PR DESCRIPTION
## Description

CI started failing with the following error:

> Warning: Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at [https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/)
  Warning: ERROR: executing pre_install.sh failed

Reason:

> October 2024: The Mambaforge installers will refuse to install during several pre-specified date ranges (i.e., ["brownouts"](https://en.wikipedia.org/wiki/Brownout_(software_engineering))) in order to encourage users to switch to Miniforge.

This PR switches from mambaforge to the latest miniforge release.
