### PR TITLE
Optionally return best graph isomorphism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@
 ## Version 0.9.0
 
 Date:            XX/YY/ZZZ
-Contributors:    @RMeli, @Jnelen
+Contributors:    @RMeli, @Jnelen, @frgoe003
 
 ### Added
 
 * `--version` CLI option [PR #131 | @RMeli]
 * `prmsdwrapper`, a first implementation of a multicore version of `rmsdwrapper`. It also supports a timeout functionality. [PR #113 | @Jnelen]
+* `return_best_isomorphism` option for `symmrmsd` calculation [PR #143 | @frgoe003]
 
 ## Version 0.8.0
 

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -267,8 +267,8 @@ def symmrmsd(
     """
 
     if isinstance(coords, list):  # Multiple RMSD calculations
-        RMSD: List[float] = []
-        best_isomorphism: List[Tuple[List[int], List[int]]] = []
+        RMSD: Any = []
+        best_isomorphism: Any = []
         isomorphism = None
 
         for c in coords:
@@ -292,14 +292,8 @@ def symmrmsd(
             RMSD.append(srmsd)
             best_isomorphism.append(best_isomorphism_)
 
-        if return_best_isomorphism:
-            return RMSD, best_isomorphism
-        return RMSD
-
     else:  # Single RMSD calculation
-        single_RMSD: float
-        single_best_isomorphism: Tuple[List[int], List[int]]
-        single_RMSD, isomorphism, single_best_isomorphism = _rmsd_isomorphic_core(
+        RMSD, isomorphism, best_isomorphism = _rmsd_isomorphic_core(
             coordsref,
             coords,
             apropsref,
@@ -313,8 +307,8 @@ def symmrmsd(
         )
 
     if return_best_isomorphism:
-        return single_RMSD, single_best_isomorphism
-    return single_RMSD
+        return RMSD, best_isomorphism
+    return RMSD
 
 
 def rmsdwrapper(

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -292,10 +292,14 @@ def symmrmsd(
             RMSD.append(srmsd)
             best_isomorphism.append(best_isomorphism_)
 
+        if return_best_isomorphism:
+            return RMSD, best_isomorphism
+        return RMSD
+
     else:  # Single RMSD calculation
-        RMSD: float
-        best_isomorphism: Tuple[List[int], List[int]]
-        RMSD, isomorphism, best_isomorphism = _rmsd_isomorphic_core(
+        single_RMSD: float
+        single_best_isomorphism: Tuple[List[int], List[int]]
+        single_RMSD, isomorphism, single_best_isomorphism = _rmsd_isomorphic_core(
             coordsref,
             coords,
             apropsref,
@@ -309,8 +313,8 @@ def symmrmsd(
         )
 
     if return_best_isomorphism:
-        return RMSD, best_isomorphism
-    return RMSD
+        return single_RMSD, single_best_isomorphism
+    return single_RMSD
 
 
 def rmsdwrapper(

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -125,7 +125,7 @@ def _rmsd_isomorphic_core(
     minimize: bool = False,
     isomorphisms: Optional[List[Tuple[List[int], List[int]]]] = None,
     atol: float = 1e-9,
-) -> Tuple[float, List[Tuple[List[int], List[int]]], Tuple[List[int], List[int]]]:
+) -> Any:
     """
     Compute RMSD using graph isomorphism.
 

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -218,12 +218,7 @@ def symmrmsd(
     cache: bool = True,
     atol: float = 1e-9,
     return_best_isomorphism: bool = False,
-) -> Union[
-    float,
-    List[float],
-    Tuple[float, Tuple[List[int], List[int]]],
-    Tuple[List[float], List[Tuple[List[int], List[int]]]],
-]:
+) -> Any:
     """
     Compute RMSD using graph isomorphism for multiple coordinates.
 

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -389,11 +389,11 @@ def test_symmrmsd_benzene_isomorphism(benzene, angle: float, shift: int) -> None
         return_best_isomorphism=True,
     )
 
-    assert best_isomorphism[1] == list(range(12))
+    assert np.all(best_isomorphism[1] == list(range(12)))
 
     # Indices should be shifted by 2 (Carbon+Hydrogen) for every 60 degrees
     expected_first_list = [(i + 2 * shift) % 12 for i in range(12)]
-    assert best_isomorphism[0] == expected_first_list
+    assert np.all(best_isomorphism[0] == expected_first_list)
 
 
 @pytest.mark.parametrize("angle", [60, 120, 180, 240, 300, 360])

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -370,6 +370,32 @@ def test_symmrmsd_rotated_benzene(benzene, angle: float) -> None:
     ) == pytest.approx(0, abs=1e-4)
 
 
+@pytest.mark.parametrize(
+    "angle, shift", [(5, 0), (65, 1), (125, 2), (185, 3), (245, 4), (305, 5)]
+)
+def test_symmrmsd_benzene_isomorphism(benzene, angle: float, shift: int) -> None:
+    mol1 = copy.deepcopy(benzene.mol)
+    mol2 = copy.deepcopy(benzene.mol)
+
+    mol2.rotate(angle, np.array([0, 0, 1]), units="deg")
+
+    _, best_isomorphism = rmsd.symmrmsd(
+        mol1.coordinates,
+        mol2.coordinates,
+        mol1.atomicnums,
+        mol2.atomicnums,
+        mol1.adjacency_matrix,
+        mol2.adjacency_matrix,
+        return_best_isomorphism=True,
+    )
+
+    assert best_isomorphism[1] == list(range(12))
+
+    # Indices should be shifted by 2 (Carbon+Hydrogen) for every 60 degrees
+    expected_first_list = [(i + 2 * shift) % 12 for i in range(12)]
+    assert best_isomorphism[0] == expected_first_list
+
+
 @pytest.mark.parametrize("angle", [60, 120, 180, 240, 300, 360])
 def test_symmrmsd_rotated_benzene_stripped(benzene, angle: float) -> None:
     mol1 = copy.deepcopy(benzene.mol)

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -371,7 +371,7 @@ def test_symmrmsd_rotated_benzene(benzene, angle: float) -> None:
 
 
 @pytest.mark.parametrize(
-    "angle, shift", [(5, 0), (65, 1), (125, 2), (185, 3), (245, 4), (305, 5)]
+    "angle, shift", [(5, 0), (65, 2), (125, 4), (185, 6), (245, 8), (305, 10)]
 )
 def test_symmrmsd_benzene_isomorphism(benzene, angle: float, shift: int) -> None:
     mol1 = copy.deepcopy(benzene.mol)

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -389,11 +389,10 @@ def test_symmrmsd_benzene_isomorphism(benzene, angle: float, shift: int) -> None
         return_best_isomorphism=True,
     )
 
-    assert np.all(best_isomorphism[1] == list(range(12)))
-
     # Indices should be shifted by 2 (Carbon+Hydrogen) for every 60 degrees
-    expected_first_list = [(i + 2 * shift) % 12 for i in range(12)]
-    assert np.all(best_isomorphism[0] == expected_first_list)
+    excpected_isomorphism = np.roll(best_isomorphism[0], shift)
+
+    assert np.all(excpected_isomorphism == best_isomorphism[1])
 
 
 @pytest.mark.parametrize("angle", [60, 120, 180, 240, 300, 360])


### PR DESCRIPTION
## Description
I found it useful to obtain the atom mapping corresponding to the lowest RMSD. This is something that RDKit's `CalcRMS` function lacks. For that I added a new function, rather than modifying `symmrmsd`, to avoid conflicts with existing implementations.

## Changes
- Added function `symmrmsd_and_isomorphism `, which is identical to `symmrmsd` but also returns the best isomorphism for each minimum RMSD
- Modified `_rmsd_isomorphic_core` to return the best isomorphism
- Adapted return value of `_rmsd_isomorphic_core` for function `symmrmsd`
- Changed type hints for function `symmrmsd`