### PR TITLE
Atomic properties and adjacency matrix for each target mol are used

### DIFF
--- a/spyrmsd/__main__.py
+++ b/spyrmsd/__main__.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         center=args.center,
         minimize=args.minimize,
         strip=not args.hydrogens,
-        cache=not args.noCache:
+        cache=not args.noCache
     )
 
     for RMSD in RMSDlist:

--- a/spyrmsd/__main__.py
+++ b/spyrmsd/__main__.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         center=args.center,
         minimize=args.minimize,
         strip=not args.hydrogens,
-        cache= args.noCache
+        cache=args.noCache,
     )
 
     for RMSD in RMSDlist:

--- a/spyrmsd/__main__.py
+++ b/spyrmsd/__main__.py
@@ -28,6 +28,9 @@ if __name__ == "__main__":
         "-n", "--nosymm", action="store_false", help="No graph isomorphism"
     )
     parser.add_argument(
+        "-k", "--noCache", action="store_false", help="Compute the isomorphism for each molecule"
+    )
+    parser.add_argument(
         "-g",
         "--graph-backend",
         type=str,
@@ -77,6 +80,7 @@ if __name__ == "__main__":
         center=args.center,
         minimize=args.minimize,
         strip=not args.hydrogens,
+        cache=not args.noCache:
     )
 
     for RMSD in RMSDlist:

--- a/spyrmsd/__main__.py
+++ b/spyrmsd/__main__.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         center=args.center,
         minimize=args.minimize,
         strip=not args.hydrogens,
-        cache=not args.noCache
+        cache= args.noCache
     )
 
     for RMSD in RMSDlist:

--- a/spyrmsd/rmsd.py
+++ b/spyrmsd/rmsd.py
@@ -210,9 +210,9 @@ def symmrmsd(
     coordsref: np.ndarray,
     coords: Union[np.ndarray, List[np.ndarray]],
     apropsref: np.ndarray,
-    aprops: np.ndarray,
+    apropsList: Union[np.ndarray, List[np.ndarray]],
     amref: np.ndarray,
-    am: np.ndarray,
+    amList: Union[np.ndarray, List[np.ndarray]],
     center: bool = False,
     minimize: bool = False,
     cache: bool = True,
@@ -230,12 +230,12 @@ def symmrmsd(
         Coordinates of other molecule
     apropsref: np.ndarray
         Atomic properties for reference
-    aprops: np.ndarray
-        Atomic properties for other molecule
+    apropsList: List[np.ndarray]
+        Atomic properties for other molecules
     amref: np.ndarray
         Adjacency matrix for reference molecule
-    am: np.ndarray
-        Adjacency matrix for other molecule
+    amList: List[np.ndarray]
+        Adjacency matrix for other molecules
     center: bool
         Centering flag
     minimize: bool
@@ -271,7 +271,7 @@ def symmrmsd(
         best_isomorphism: Any = []
         isomorphism = None
 
-        for c in coords:
+        for i, c in enumerate(coords):
             if not cache:
                 # Reset isomorphism
                 isomorphism = None
@@ -280,9 +280,9 @@ def symmrmsd(
                 coordsref,
                 c,
                 apropsref,
-                aprops,
+                apropsList[i],
                 amref,
-                am,
+                amList[i],
                 center=center,
                 minimize=minimize,
                 isomorphisms=isomorphism,
@@ -297,9 +297,9 @@ def symmrmsd(
             coordsref,
             coords,
             apropsref,
-            aprops,
+            apropsList,
             amref,
-            am,
+            amList,
             center=center,
             minimize=minimize,
             isomorphisms=None,
@@ -358,6 +358,8 @@ def rmsdwrapper(
 
     cref = molecule.coords_from_molecule(molref, center)
     cmols = [molecule.coords_from_molecule(mol, center) for mol in mols]
+    apropsList = [mol.atomicnums for mol in mols]
+    amList = [mol.adjacency_matrix for mol in mols]
 
     RMSDlist = []
 
@@ -366,21 +368,21 @@ def rmsdwrapper(
             cref,
             cmols,
             molref.atomicnums,
-            mols[0].atomicnums,
+            apropsList,
             molref.adjacency_matrix,
-            mols[0].adjacency_matrix,
+            amList,
             center=center,
             minimize=minimize,
             cache=cache,
         )
     else:  # No symmetry
-        for c in cmols:
+        for i, c in enumerate(cmols):
             RMSDlist.append(
                 rmsd(
                     cref,
                     c,
                     molref.atomicnums,
-                    mols[0].atomicnums,
+                    apropsList[i],
                     center=center,
                     minimize=minimize,
                 )


### PR DESCRIPTION
## Description

This PR is meant to solve an issue when calculating the RMSD on a list of target molecules. At least when using the command line, def symmrmsd iterates over the target molecules coordinates and send them to _rmsd_isomorphic_core for the calculation.
However, the atomic properties and adjacency matrix sent is the one of the first target molecule (lines 369 and 371):

mols[0].atomicnums
mols[0].adjacency_matrix

This assumes that the properties and adjacency matrix of all the target molecules are all the same, which was not my case, and leads to incorrect RMSD calculations. As we have that information for each of the molecules, it is not difficult to just pass the respective atomic properties and adjacency matrix for each of the molecules.

I have not tested in depth if my changes break anything else though, so please take it into account first. 



## Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Changelog
