### PR TITLE
Add optional xyzgraph adjacency builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 ## Version 0.Y.Z
 
 Date:            DD/MM/YYYY
-Contributors: @RMeli
+Contributors: @RMeli, @JamesOBrien2
 
 ### Added
 
+* Optional `xyzgraph` adjacency matrix builder [PR #157 | @JamesOBrien2]
 * Python `3.13` and `3.14` in CI [PR #147 | @RMeli]
 * Optional dependencies for testing (`test`), development (`dev`), and parallelization (`parallel`) in `pyproject.toml` [PR #152 | @copilot]
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ One of the following graph libraries is required:
 > [!NOTE]
 > `spyrmsd` uses the following priority when multiple graph libraries are present: [graph-tool], [rustworkx], [NetworkX]. *This order might change. Use `set_backend` to ensure you are always using the same backend, if needed.*
 
+The xyzgraph adapter is optional:
+* [xyzgraph](https://github.com/aligfellow/xyzgraph) (install with `pip install spyrmsd[xyzgraph]`)
+
 #### Standalone Tool
 
 Additionally, the following package is required to use `spyrmsd` as a standalone tool:
@@ -146,6 +149,34 @@ def symmrmsd(
 
 > [!NOTE]
 > Atomic properties (`aprops`) can be any Python object when using [NetworkX] and [rustworkx], or integers, floats, or strings when using [graph-tool](https://graph-tool.skewed.de/).
+
+#### xyzgraph Adapter
+
+If you want to use `xyzgraph` as an optional adjacency builder, build the
+adjacency matrix first and then pass it to the existing `symmrmsd` interface.
+
+```python
+from spyrmsd.adapters.xyzgraph import (
+    adjacency_matrix_from_atomic_coordinates as xyzgraph_adjacency_matrix,
+)
+from spyrmsd.rmsd import symmrmsd
+
+amref = xyzgraph_adjacency_matrix(atomicnums_ref, coords_ref)
+am = xyzgraph_adjacency_matrix(atomicnums, coords)
+
+value = symmrmsd(
+    coords_ref,
+    coords,
+    atomicnums_ref,
+    atomicnums,
+    amref,
+    am,
+)
+print(value)
+```
+
+This keeps the public API aligned with the existing `spyrmsd` workflow while
+making `xyzgraph` available as an opt-in topology builder.
 
 #### Select Backend
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ sPyRMSD documentation
 
    installation
    tutorials/tutorial
+   xyzgraph_adapter
    api
 
 Indices and tables

--- a/docs/source/xyzgraph_adapter.rst
+++ b/docs/source/xyzgraph_adapter.rst
@@ -1,0 +1,40 @@
+xyzgraph Adapter
+================
+
+``spyrmsd`` can use `xyzgraph <https://github.com/aligfellow/xyzgraph>`_ as an
+optional adjacency matrix builder for molecular graph construction.
+
+Install the optional dependency with:
+
+.. code-block:: bash
+
+   pip install spyrmsd[xyzgraph]
+
+The adapter keeps the same high-level workflow already used by ``spyrmsd``:
+first build an adjacency matrix, then pass it to :func:`spyrmsd.rmsd.symmrmsd`.
+
+Example
+-------
+
+.. code-block:: python
+
+   from spyrmsd.adapters.xyzgraph import (
+       adjacency_matrix_from_atomic_coordinates as xyzgraph_adjacency_matrix,
+   )
+   from spyrmsd.rmsd import symmrmsd
+
+   amref = xyzgraph_adjacency_matrix(atomicnums_ref, coords_ref)
+   am = xyzgraph_adjacency_matrix(atomicnums, coords)
+
+   value = symmrmsd(
+       coords_ref,
+       coords,
+       atomicnums_ref,
+       atomicnums,
+       amref,
+       am,
+   )
+
+.. note::
+   The default graph builder remains the built-in ``simple`` one,
+   based on distance and VdW radii. The ``xyzgraph`` adapter is opt-in.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ Homepage = "https://spyrmsd.readthedocs.io"
 bib = ["duecredit"]
 rdkit = ["rdkit"]
 networkx = ["networkx"]
+xyzgraph = ["xyzgraph; python_version >= '3.10'"]
 parallel = ["pebble"]
 test = [
     "pytest",

--- a/spyrmsd/__main__.py
+++ b/spyrmsd/__main__.py
@@ -2,16 +2,17 @@
 Symmetry-corrected RMSD calculations in Python
 """
 
-if __name__ == "__main__":
-    import argparse as ap
-    import importlib.util
-    import sys
-    import warnings
+import argparse as ap
+import importlib.util
+import sys
+import warnings
 
-    import spyrmsd
-    from spyrmsd import io
-    from spyrmsd.rmsd import rmsdwrapper
+import spyrmsd
+from spyrmsd import graph, io, molecule
+from spyrmsd.rmsd import rmsdwrapper
 
+
+def build_parser() -> ap.ArgumentParser:
     parser = ap.ArgumentParser(
         prog="spyrmsd",
         description="Symmetry-corrected RMSD calculations in Python.",
@@ -28,6 +29,16 @@ if __name__ == "__main__":
         "-n", "--nosymm", action="store_false", help="No graph isomorphism"
     )
     parser.add_argument(
+        "--graph-builder",
+        dest="graph_builder",
+        choices=("simple", "xyzgraph"),
+        default="simple",
+        help=(
+            "Adjacency matrix builder "
+            "(xyzgraph: Molecular Graph Construction from Cartesian Coordinates)"
+        ),
+    )
+    parser.add_argument(
         "-g",
         "--graph-backend",
         type=str,
@@ -41,6 +52,11 @@ if __name__ == "__main__":
         "-V", "--version", action="version", version=f"%(prog)s {spyrmsd.__version__}"
     )
 
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
     args = parser.parse_args()
 
     if importlib.util.find_spec("rdkit") is None:
@@ -52,32 +68,60 @@ if __name__ == "__main__":
         ref = io.loadmol(args.reference)
     except OSError:
         print("ERROR: Reference file not found.", file=sys.stderr)
-        exit(-1)
+        return -1
 
-    # Load all molecules
     try:
         mols = [mol for molfile in args.molecules for mol in io.loadallmols(molfile)]
     except OSError:
         print("ERROR: Molecule file(s) not found.", file=sys.stderr)
-        exit(-1)
+        return -1
 
     if args.graph_backend is not None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             spyrmsd.set_backend(args.graph_backend)
 
+    try:
+        graph.set_graph_builder(args.graph_builder)
+        ref = molecule.Molecule(
+            ref.atomicnums,
+            ref.coordinates,
+            adjacency_matrix=graph.adjacency_matrix_from_atomic_coordinates(
+                ref.atomicnums, ref.coordinates
+            ),
+        )
+        mols = [
+            molecule.Molecule(
+                mol.atomicnums,
+                mol.coordinates,
+                adjacency_matrix=graph.adjacency_matrix_from_atomic_coordinates(
+                    mol.atomicnums, mol.coordinates
+                ),
+            )
+            for mol in mols
+        ]
+    except (ImportError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return -1
+
     if args.verbose:
         print(f"Graph library: {spyrmsd.get_backend()}")
+        print(f"Graph builder: {graph.get_graph_builder()}")
 
-    # Loop over molecules within fil
-    RMSDlist = rmsdwrapper(
+    rmsd_list = rmsdwrapper(
         ref,
         mols,
-        symmetry=args.nosymm,  # args.nosymm store False
+        symmetry=args.nosymm,
         center=args.center,
         minimize=args.minimize,
         strip=not args.hydrogens,
     )
 
-    for RMSD in RMSDlist:
-        print(f"{RMSD:.5f}")
+    for rmsd in rmsd_list:
+        print(f"{rmsd:.5f}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spyrmsd/adapters/__init__.py
+++ b/spyrmsd/adapters/__init__.py
@@ -1,0 +1,3 @@
+"""
+Adapters for optional interoperability helpers.
+"""

--- a/spyrmsd/adapters/simple.py
+++ b/spyrmsd/adapters/simple.py
@@ -1,0 +1,53 @@
+"""
+Simple built-in adjacency matrix builder.
+"""
+
+import numpy as np
+
+from spyrmsd import constants
+
+
+def adjacency_matrix_from_atomic_coordinates(
+    aprops: np.ndarray, coordinates: np.ndarray
+) -> np.ndarray:
+    """
+    Compute an adjacency matrix with a distance heuristic.
+
+    Notes
+    -----
+
+    This function is based on an automatic bond perception algorithm: two
+    atoms are considered to be bonded when their distance is smaller than
+    the sum of their covalent radii plus a tolerance value. [3]_
+
+    .. warning::
+        The automatic bond perception rule implemented in this function
+        is very simple and only depends on atomic coordinates. Use
+        with care!
+
+    .. [3] E. C. Meng and R. A. Lewis, *Determination of molecular topology and atomic
+       hybridization states from heavy atom coordinates*, J. Comp. Chem. **12**, 891-898
+       (1991).
+    """
+
+    n = len(aprops)
+
+    assert coordinates.shape == (n, 3)
+
+    A = np.zeros((n, n))
+
+    for i in range(n):
+        r_i = constants.anum_to_covalentradius[aprops[i]]
+
+        for j in range(i + 1, n):
+            r_j = constants.anum_to_covalentradius[aprops[j]]
+
+            distance = np.sqrt(np.sum((coordinates[i] - coordinates[j]) ** 2))
+
+            if distance < (r_i + r_j + constants.connectivity_tolerance):
+                A[i, j] = A[j, i] = 1
+
+    return A
+
+
+__all__ = ["adjacency_matrix_from_atomic_coordinates"]

--- a/spyrmsd/adapters/xyzgraph.py
+++ b/spyrmsd/adapters/xyzgraph.py
@@ -1,0 +1,83 @@
+"""
+Optional xyzgraph-based adjacency builder.
+"""
+
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
+from spyrmsd import constants
+
+
+def _atomic_number_to_symbol(atomic_number: int) -> str:
+    try:
+        return constants.anum_to_symbol[atomic_number]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unsupported atomic number for xyzgraph adapter: {atomic_number}"
+        ) from exc
+
+
+def _atoms_from_arrays(
+    aprops: Sequence[int], coordinates: np.ndarray
+) -> List[Tuple[str, Tuple[float, float, float]]]:
+    n_atoms = len(aprops)
+
+    assert coordinates.shape == (n_atoms, 3)
+
+    atoms = []
+    for atomic_number, position in zip(aprops, coordinates):
+        symbol = _atomic_number_to_symbol(int(atomic_number))
+        xyz_position = (
+            float(position[0]),
+            float(position[1]),
+            float(position[2]),
+        )
+        atoms.append((symbol, xyz_position))
+
+    return atoms
+
+
+def adjacency_matrix_from_atomic_coordinates(
+    aprops: np.ndarray, coordinates: np.ndarray
+) -> np.ndarray:
+    """
+    Compute an adjacency matrix from atomic coordinates using xyzgraph.
+
+    Parameters
+    ----------
+    aprops: numpy.ndarray
+        Atomic numbers.
+    coordinates: numpy.ndarray
+        Atomic coordinates.
+    Returns
+    -------
+    numpy.ndarray
+        Adjacency matrix.
+    """
+
+    try:
+        from xyzgraph import build_graph
+    except ImportError as exc:
+        raise ImportError(
+            "xyzgraph is required for the xyzgraph graph builder. "
+            "Install with `pip install spyrmsd[xyzgraph]`."
+        ) from exc
+
+    atoms = _atoms_from_arrays(aprops, coordinates)
+    graph = build_graph(atoms)
+
+    n_atoms = len(aprops)
+    adjacency = np.zeros((n_atoms, n_atoms), dtype=int)
+
+    for i, j in graph.edges():
+        ii = int(i)
+        jj = int(j)
+        if ii < 0 or jj < 0 or ii >= n_atoms or jj >= n_atoms:
+            raise ValueError("xyzgraph adapter received out-of-range node indices.")
+        adjacency[ii, jj] = adjacency[jj, ii] = 1
+
+    return adjacency
+
+
+__all__ = ["adjacency_matrix_from_atomic_coordinates"]

--- a/spyrmsd/constants.py
+++ b/spyrmsd/constants.py
@@ -13,6 +13,31 @@ from typing import Dict
 
 connectivity_tolerance: float = 0.4
 
+# Keep the elements grouped like the periodic table.
+# fmt: off
+_anum_to_symbol_data = (
+    "",
+    "H", "He",
+    "Li", "Be", "B", "C", "N", "O", "F", "Ne",
+    "Na", "Mg", "Al", "Si", "P", "S", "Cl", "Ar",
+    "K", "Ca", "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
+    "Ga", "Ge", "As", "Se", "Br", "Kr",
+    "Rb", "Sr", "Y", "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd",
+    "In", "Sn", "Sb", "Te", "I", "Xe",
+    "Cs", "Ba", "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy",
+    "Ho", "Er", "Tm", "Yb", "Lu", "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt",
+    "Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn",
+    "Fr", "Ra", "Ac", "Th", "Pa", "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf",
+    "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds",
+    "Rg", "Cn", "Nh", "Fl", "Mc", "Lv", "Ts", "Og",
+)
+# fmt: on
+
+
+anum_to_symbol: Dict = {
+    anum: symbol for anum, symbol in enumerate(_anum_to_symbol_data) if anum > 0
+}
+
 # Values from QCElemental
 anum_to_mass: Dict = {
     1: 1.00782503223,

--- a/spyrmsd/graph.py
+++ b/spyrmsd/graph.py
@@ -3,8 +3,6 @@ import warnings
 
 import numpy as np
 
-from spyrmsd import constants
-
 # The first backend found from this list is set as default
 # TODO: Need to determine if graph_tool or rustworkx is better
 # NetworkX is slow, therefore it is the last resort
@@ -12,6 +10,8 @@ _supported_backends = ("graph_tool", "rustworkx", "networkx")
 
 _available_backends = []
 _current_backend = None
+_supported_graph_builders = ("simple", "xyzgraph")
+_current_graph_builder = "simple"
 
 _backend_to_alias = {
     "graph_tool": ["graph_tool", "graphtool", "graph-tool", "graph tool", "gt"],
@@ -184,6 +184,39 @@ def _get_backend():
     return _current_backend
 
 
+def _validate_graph_builder(graph_builder):
+    """
+    Validate graph builder.
+    """
+    if graph_builder not in _supported_graph_builders:
+        raise ValueError(
+            f"The {graph_builder} graph builder is not recognized or supported"
+        )
+
+    return graph_builder
+
+
+def set_graph_builder(graph_builder):
+    """
+    Set graph builder used for adjacency construction.
+    """
+    global _current_graph_builder
+
+    graph_builder = _validate_graph_builder(graph_builder)
+
+    if graph_builder == _current_graph_builder:
+        return
+
+    _current_graph_builder = graph_builder
+
+
+def get_graph_builder():
+    """
+    Get the current graph builder.
+    """
+    return _current_graph_builder
+
+
 def adjacency_matrix_from_atomic_coordinates(
     aprops: np.ndarray, coordinates: np.ndarray
 ) -> np.ndarray:
@@ -202,38 +235,22 @@ def adjacency_matrix_from_atomic_coordinates(
     numpy.ndarray
         Adjacency matrix
 
-    Notes
-    -----
-
-    This function is based on an automatic bond perception algorithm: two
-    atoms are considered to be bonded when their distance is smaller than
-    the sum of their covalent radii plus a tolerance value. [3]_
-
-    .. warning::
-        The automatic bond perceptron rule implemented in this functions
-        is very simple and only depends on atomic coordinates. Use
-        with care!
-
-    .. [3] E. C. Meng and R. A. Lewis, *Determination of molecular topology and atomic
-       hybridization states from heavy atom coordinates*, J. Comp. Chem. **12**, 891-898
-       (1991).
     """
 
-    n = len(aprops)
+    if _current_graph_builder == "simple":
+        from spyrmsd.adapters.simple import (
+            adjacency_matrix_from_atomic_coordinates as simple_adjacency_matrix,
+        )
 
-    assert coordinates.shape == (n, 3)
+        return simple_adjacency_matrix(aprops, coordinates)
 
-    A = np.zeros((n, n))
+    if _current_graph_builder == "xyzgraph":
+        from spyrmsd.adapters.xyzgraph import (
+            adjacency_matrix_from_atomic_coordinates as xyzgraph_adjacency_matrix,
+        )
 
-    for i in range(n):
-        r_i = constants.anum_to_covalentradius[aprops[i]]
+        return xyzgraph_adjacency_matrix(aprops, coordinates)
 
-        for j in range(i + 1, n):
-            r_j = constants.anum_to_covalentradius[aprops[j]]
-
-            distance = np.sqrt(np.sum((coordinates[i] - coordinates[j]) ** 2))
-
-            if distance < (r_i + r_j + constants.connectivity_tolerance):
-                A[i, j] = A[j, i] = 1
-
-    return A
+    raise ValueError(
+        f"The {_current_graph_builder} graph builder is not recognized or supported"
+    )

--- a/tests/test_adapters_xyzgraph.py
+++ b/tests/test_adapters_xyzgraph.py
@@ -1,0 +1,144 @@
+import builtins
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from spyrmsd import rmsd
+from spyrmsd.adapters.xyzgraph import adjacency_matrix_from_atomic_coordinates
+
+
+class _FakeGraph:
+    def __init__(self, edges):
+        self._edges = edges
+
+    def edges(self):
+        return list(self._edges)
+
+
+@pytest.fixture
+def fake_xyzgraph(monkeypatch):
+    calls = []
+
+    def build_graph(atoms):
+        calls.append(
+            {
+                "atoms": atoms,
+            }
+        )
+
+        if len(atoms) == 2:
+            return _FakeGraph([(0, 1)])
+
+        return _FakeGraph([(0, 1), (0, 2)])
+
+    module = types.SimpleNamespace(build_graph=build_graph)
+    monkeypatch.setitem(sys.modules, "xyzgraph", module)
+    return calls
+
+
+def test_xyzgraph_adjacency_returns_symmetric_matrix(fake_xyzgraph):
+    atomicnums = np.array([8, 1, 1])
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.95, 0.0, 0.0], [-0.24, 0.92, 0.0]])
+
+    adjacency = adjacency_matrix_from_atomic_coordinates(atomicnums, coordinates)
+
+    assert np.array_equal(
+        adjacency,
+        np.array([[0, 1, 1], [1, 0, 0], [1, 0, 0]]),
+    )
+
+
+def test_xyzgraph_adjacency_preserves_input_atom_order(fake_xyzgraph):
+    atomicnums = np.array([6, 8, 1])
+    coordinates = np.array([[3.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+
+    adjacency_matrix_from_atomic_coordinates(atomicnums, coordinates)
+
+    assert fake_xyzgraph[0]["atoms"] == [
+        ("C", (3.0, 0.0, 0.0)),
+        ("O", (1.0, 0.0, 0.0)),
+        ("H", (2.0, 0.0, 0.0)),
+    ]
+
+
+def test_xyzgraph_adjacency_import_error(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "xyzgraph":
+            raise ImportError("No module named 'xyzgraph'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.delitem(sys.modules, "xyzgraph", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    atomicnums = np.array([1, 1])
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.7]])
+
+    with pytest.raises(ImportError, match="xyzgraph"):
+        adjacency_matrix_from_atomic_coordinates(atomicnums, coordinates)
+
+
+def test_xyzgraph_adjacency_rejects_unknown_atomic_number(fake_xyzgraph):
+    with pytest.raises(ValueError, match="Unsupported atomic number"):
+        adjacency_matrix_from_atomic_coordinates(
+            np.array([0]), np.array([[0.0, 0.0, 0.0]])
+        )
+
+
+def test_xyzgraph_adjacency_rejects_out_of_range_edges(monkeypatch):
+    module = types.SimpleNamespace(build_graph=lambda atoms: _FakeGraph([(0, 2)]))
+    monkeypatch.setitem(sys.modules, "xyzgraph", module)
+
+    with pytest.raises(ValueError, match="out-of-range node indices"):
+        adjacency_matrix_from_atomic_coordinates(
+            np.array([1, 1]),
+            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.7]]),
+        )
+
+
+def test_xyzgraph_adjacency_integrates_with_symmrmsd(fake_xyzgraph):
+    atomicnums = np.array([8, 1, 1])
+    coords_ref = np.array([[0.0, 0.0, 0.0], [0.95, 0.0, 0.0], [-0.24, 0.92, 0.0]])
+    coords_pose = coords_ref.copy()
+
+    adjacency = adjacency_matrix_from_atomic_coordinates(atomicnums, coords_ref)
+
+    value = rmsd.symmrmsd(
+        coords_ref,
+        coords_pose,
+        atomicnums,
+        atomicnums,
+        adjacency,
+        adjacency,
+    )
+
+    assert value == pytest.approx(0.0, abs=1e-12)
+
+
+def test_xyzgraph_adjacency_live_smoke():
+    try:
+        __import__("xyzgraph")
+    except Exception:
+        pytest.skip("xyzgraph is not importable in this environment")
+
+    atomicnums = np.array([1, 1])
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.7]])
+
+    adjacency = adjacency_matrix_from_atomic_coordinates(atomicnums, coordinates)
+
+    assert adjacency.shape == (2, 2)
+    assert np.array_equal(adjacency, adjacency.T)
+    assert adjacency[0, 1] == 1
+
+    value = rmsd.symmrmsd(
+        coordinates,
+        coordinates.copy(),
+        atomicnums,
+        atomicnums,
+        adjacency,
+        adjacency,
+    )
+
+    assert value == pytest.approx(0.0, abs=1e-12)

--- a/tests/test_cli_graph_builder.py
+++ b/tests/test_cli_graph_builder.py
@@ -1,0 +1,201 @@
+import builtins
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from spyrmsd import __main__ as cli
+from spyrmsd import graph
+from spyrmsd.adapters import xyzgraph as xyzgraph_adapter
+
+
+@pytest.fixture(autouse=True)
+def reset_graph_builder():
+    graph.set_graph_builder("simple")
+    yield
+    graph.set_graph_builder("simple")
+
+
+def run_cli(monkeypatch, *args):
+    monkeypatch.setattr(sys, "argv", ["spyrmsd", *args])
+    return cli.main()
+
+
+def test_main_requires_rdkit(monkeypatch):
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda name: None)
+
+    with pytest.raises(ImportError, match="RDKit not found"):
+        run_cli(monkeypatch, "ref.sdf", "poses.sdf")
+
+
+def test_main_reports_missing_reference(monkeypatch, capsys):
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(
+        cli.io, "loadmol", lambda path: (_ for _ in ()).throw(OSError())
+    )
+
+    assert run_cli(monkeypatch, "missing.sdf", "poses.sdf") == -1
+    assert capsys.readouterr().err == "ERROR: Reference file not found.\n"
+
+
+def test_main_reports_missing_molecules(monkeypatch, capsys):
+    fake_mol = types.SimpleNamespace(
+        atomicnums=np.array([1]),
+        coordinates=np.zeros((1, 3)),
+    )
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(cli.io, "loadmol", lambda path: fake_mol)
+    monkeypatch.setattr(
+        cli.io, "loadallmols", lambda path: (_ for _ in ()).throw(OSError())
+    )
+
+    assert run_cli(monkeypatch, "ref.sdf", "missing.sdf") == -1
+    assert capsys.readouterr().err == "ERROR: Molecule file(s) not found.\n"
+
+
+def test_main_default_path_uses_io(monkeypatch, capsys):
+    fake_mol = types.SimpleNamespace(
+        atomicnums=np.array([8, 1, 1]),
+        coordinates=np.zeros((3, 3)),
+        adjacency_matrix=np.zeros((3, 3), dtype=int),
+    )
+
+    monkeypatch.setattr(
+        cli.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "rdkit" else None,
+    )
+    monkeypatch.setattr(cli.io, "loadmol", lambda p: fake_mol)
+    monkeypatch.setattr(cli.io, "loadallmols", lambda p: [fake_mol, fake_mol])
+    monkeypatch.setattr(
+        cli,
+        "rmsdwrapper",
+        lambda ref, mols, symmetry, center, minimize, strip, cache=True: [0.1, 0.2],
+    )
+
+    rc = run_cli(monkeypatch, "ref.sdf", "poses.sdf")
+
+    assert rc == 0
+    assert graph.get_graph_builder() == "simple"
+    assert capsys.readouterr().out.strip().splitlines() == ["0.10000", "0.20000"]
+
+
+def test_main_sets_graph_backend(monkeypatch):
+    fake_mol = types.SimpleNamespace(
+        atomicnums=np.array([1]),
+        coordinates=np.zeros((1, 3)),
+    )
+    selected = []
+
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(cli.io, "loadmol", lambda path: fake_mol)
+    monkeypatch.setattr(cli.io, "loadallmols", lambda path: [fake_mol])
+    monkeypatch.setattr(cli.spyrmsd, "set_backend", selected.append)
+    monkeypatch.setattr(cli, "rmsdwrapper", lambda *args, **kwargs: [0.0])
+
+    assert (
+        run_cli(monkeypatch, "--graph-backend", "networkx", "ref.sdf", "poses.sdf") == 0
+    )
+    assert selected == ["networkx"]
+
+
+def test_main_xyzgraph_builder_rebuilds_adjacency(monkeypatch, capsys):
+    fake_mol = types.SimpleNamespace(
+        atomicnums=np.array([8, 1, 1]),
+        coordinates=np.zeros((3, 3)),
+        adjacency_matrix=np.zeros((3, 3), dtype=int),
+    )
+    monkeypatch.setattr(
+        xyzgraph_adapter,
+        "adjacency_matrix_from_atomic_coordinates",
+        lambda aprops, coordinates: np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]]),
+    )
+
+    monkeypatch.setattr(
+        cli.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "rdkit" else None,
+    )
+    monkeypatch.setattr(cli.io, "loadmol", lambda p: fake_mol)
+    monkeypatch.setattr(cli.io, "loadallmols", lambda p: [fake_mol])
+    seen = {}
+
+    def fake_rmsdwrapper(ref, mols, symmetry, center, minimize, strip, cache=True):
+        seen["ref"] = ref
+        seen["mols"] = mols
+        return [0.0]
+
+    monkeypatch.setattr(cli, "rmsdwrapper", fake_rmsdwrapper)
+
+    rc = run_cli(monkeypatch, "--graph-builder", "xyzgraph", "ref.xyz", "poses.xyz")
+
+    assert rc == 0
+    assert graph.get_graph_builder() == "xyzgraph"
+    assert np.array_equal(
+        seen["ref"].adjacency_matrix,
+        np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]]),
+    )
+    assert np.array_equal(
+        seen["mols"][0].adjacency_matrix,
+        np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]]),
+    )
+    assert capsys.readouterr().out.strip() == "0.00000"
+
+
+def test_main_xyzgraph_builder_missing_dependency(monkeypatch, capsys):
+    fake_mol = types.SimpleNamespace(
+        atomicnums=np.array([8, 1, 1]),
+        coordinates=np.zeros((3, 3)),
+        adjacency_matrix=np.zeros((3, 3), dtype=int),
+    )
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "xyzgraph":
+            raise ImportError("No module named 'xyzgraph'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(
+        cli.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "rdkit" else None,
+    )
+    monkeypatch.setattr(cli.io, "loadmol", lambda p: fake_mol)
+    monkeypatch.setattr(cli.io, "loadallmols", lambda p: [fake_mol])
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    rc = run_cli(monkeypatch, "--graph-builder", "xyzgraph", "ref.xyz", "poses.xyz")
+
+    assert rc == -1
+    err = capsys.readouterr().err
+    assert err.startswith("ERROR: xyzgraph is required for the xyzgraph graph builder")
+
+
+def test_main_verbose_prints_library_and_builder(monkeypatch, capsys):
+    fake_mol = types.SimpleNamespace(
+        atomicnums=np.array([8, 1, 1]),
+        coordinates=np.zeros((3, 3)),
+        adjacency_matrix=np.zeros((3, 3), dtype=int),
+    )
+
+    monkeypatch.setattr(
+        cli.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "rdkit" else None,
+    )
+    monkeypatch.setattr(cli.io, "loadmol", lambda p: fake_mol)
+    monkeypatch.setattr(cli.io, "loadallmols", lambda p: [fake_mol])
+    monkeypatch.setattr(
+        cli,
+        "rmsdwrapper",
+        lambda ref, mols, symmetry, center, minimize, strip, cache=True: [0.0],
+    )
+
+    rc = run_cli(monkeypatch, "--verbose", "ref.sdf", "poses.sdf")
+
+    assert rc == 0
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0].startswith("Graph library:")
+    assert lines[1] == "Graph builder: simple"
+    assert lines[2] == "0.00000"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,10 +1,22 @@
+import importlib
+
 import numpy as np
 import pytest
 
 import spyrmsd
 from spyrmsd import constants, graph, io
+from spyrmsd.adapters.simple import (
+    adjacency_matrix_from_atomic_coordinates as simple_adjacency_matrix,
+)
 from spyrmsd.exceptions import NonIsomorphicGraphs
 from spyrmsd.graphs import _common as gc
+
+
+@pytest.fixture(autouse=True)
+def reset_graph_builder():
+    graph.set_graph_builder("simple")
+    yield
+    graph.set_graph_builder("simple")
 
 
 def test_adjacency_matrix_from_atomic_coordinates_distance() -> None:
@@ -36,6 +48,57 @@ def test_adjacency_matrix_from_atomic_coordinates(mol) -> None:
 
     assert graph.num_vertices(G) == mol.n_atoms
     assert graph.num_edges(G) == mol.n_bonds
+
+
+def test_adjacency_matrix_simple_adapter_parity(mol) -> None:
+    from_graph = graph.adjacency_matrix_from_atomic_coordinates(
+        mol.mol.atomicnums, mol.mol.coordinates
+    )
+    from_adapter = simple_adjacency_matrix(mol.mol.atomicnums, mol.mol.coordinates)
+
+    assert np.array_equal(from_graph, from_adapter)
+
+
+def test_graph_builder_defaults_to_simple() -> None:
+    assert graph.get_graph_builder() == "simple"
+
+
+def test_set_graph_builder_rejects_unknown_builder() -> None:
+    with pytest.raises(ValueError, match="graph builder"):
+        graph.set_graph_builder("unknown")
+
+
+def test_xyzgraph_builder_dispatch(monkeypatch) -> None:
+    calls = []
+
+    def fake_xyzgraph_adjacency(aprops, coordinates):
+        calls.append((aprops.copy(), coordinates.copy()))
+        return np.array([[0, 1], [1, 0]], dtype=int)
+
+    xyzgraph_adapter = importlib.import_module("spyrmsd.adapters.xyzgraph")
+
+    monkeypatch.setattr(
+        xyzgraph_adapter,
+        "adjacency_matrix_from_atomic_coordinates",
+        fake_xyzgraph_adjacency,
+    )
+    graph.set_graph_builder("xyzgraph")
+
+    adjacency = graph.adjacency_matrix_from_atomic_coordinates(
+        np.array([1, 1]), np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.7]])
+    )
+
+    assert len(calls) == 1
+    assert np.array_equal(adjacency, np.array([[0, 1], [1, 0]], dtype=int))
+
+
+def test_graph_builder_dispatch_rejects_invalid_internal_state(monkeypatch) -> None:
+    monkeypatch.setattr(graph, "_current_graph_builder", "unknown")
+
+    with pytest.raises(ValueError, match="unknown graph builder"):
+        graph.adjacency_matrix_from_atomic_coordinates(
+            np.array([1]), np.array([[0.0, 0.0, 0.0]])
+        )
 
 
 def test_adjacency_matrix_from_mol(rawmol) -> None:


### PR DESCRIPTION
## Description

Adds `xyzgraph` as an optional adjacency matrix builder alongside the existing distance-based heuristic. The built-in builder remains the default, while library and CLI users can opt into `xyzgraph` when constructing molecular topology from coordinates.

## Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog