### PR TITLE
Add AI policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 25.12.0
+    rev: 26.3.1
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8
@@ -22,12 +22,12 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/PyCQA/isort
-    rev: 7.0.0
+    rev: 8.0.1
     hooks:
     -   id: isort
         args: ["--profile", "black"]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/AI.md
+++ b/AI.md
@@ -29,7 +29,7 @@ When AI tools contribute to `spyrmsd` development, proper attribution helps trac
 Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
 ```
 
-Where `AGENT_NAME` is the name of the AI tool or framework, 
+Where `AGENT_NAME` is the name of the AI tool or framework,
 `MODEL_VERSION` is the specific model version used, and
 `[TOOL1] [TOOL2]` are optional specialized analysis tools used.
 Basic development tools (git, gcc, make, editors) should not be listed.

--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,35 @@
+# AI Coding Assistants
+
+This document provides guidance for AI tools and developers using AI assistance when contributing to `spyrmsd`.
+
+AI tools helping with `spyrmsd` development should follow the standard development process.
+
+## Licensing and Legal Requirements
+
+All contributions must comply with the `spyrmsd`'s licensing requirements:
+
+* All code must be compatible with the MIT license
+* Use appropriate SPDX license identifiers
+
+
+## Signed-off-by and Developer Certificate of Origin
+
+AI agents MUST NOT add Signed-off-by tags. Only humans can legally certify the Developer Certificate of Origin (DCO). The human submitter is responsible for:
+
+* Reviewing all AI-generated code
+* Ensuring compliance with licensing requirements
+* Adding their own Signed-off-by tag to certify the DCO
+* Taking full responsibility for the contribution
+
+## Attribution
+
+When AI tools contribute to `spyrmsd` development, proper attribution helps track the evolving role of AI in the development process. Contributions should include an Assisted-by tag in the following format:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+
+Where `AGENT_NAME` is the name of the AI tool or framework, 
+`MODEL_VERSION` is the specific model version used, and
+`[TOOL1] [TOOL2]` are optional specialized analysis tools used.
+Basic development tools (git, gcc, make, editors) should not be listed.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ The available backends (which depend on the installed dependencies) are stored i
 
 ## Development
 
+> [!WARNING]
+> Please check out our [AI policy](AI.md) for the use of AI tools in development.
+
 To ensure code quality and consistency the following tools are used during development:
 
 * [black](https://black.readthedocs.io/en/stable/)


### PR DESCRIPTION
Add AI policy, based on the [Linux Kernel AI policy](https://docs.kernel.org/process/coding-assistants.html).